### PR TITLE
Bugfix/option string

### DIFF
--- a/src/de/variant_de.rs
+++ b/src/de/variant_de.rs
@@ -46,9 +46,20 @@ impl<'de> serde::Deserializer<'de> for Variant {
         }
     }
 
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            Variant::Null => visitor.visit_none(),
+            Variant::Empty => visitor.visit_none(),
+            some => visitor.visit_some(some),
+        }
+    }
+
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        bytes byte_buf unit unit_struct newtype_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
     }
 }

--- a/src/de/wbem_class_de.rs
+++ b/src/de/wbem_class_de.rs
@@ -270,10 +270,7 @@ mod tests {
         #[derive(Deserialize, Debug)]
         pub struct Win32_Service {
             pub Name: String,
-            pub DisplayName: String,
             pub PathName: Option<String>,
-            pub State: String,
-            pub Started: bool,
         }
 
         let results: Vec<Win32_Service> = wmi_con.query().unwrap();

--- a/src/de/wbem_class_de.rs
+++ b/src/de/wbem_class_de.rs
@@ -275,9 +275,18 @@ mod tests {
 
         let results: Vec<Win32_Service> = wmi_con.query().unwrap();
 
-        for res in results {
-            assert_eq!(res.Name, "S");
-            assert_eq!(res.PathName, Some("a".to_owned()));
-        }
+        let lsm_service = results
+            .iter()
+            .find(|&service| service.Name == "LSM")
+            .unwrap();
+
+        assert_eq!(lsm_service.PathName, None);
+
+        let lmhosts_service = results
+            .iter()
+            .find(|&service| service.Name == "lmhosts")
+            .unwrap();
+
+        assert!(lmhosts_service.PathName.is_some());
     }
 }

--- a/src/de/wbem_class_de.rs
+++ b/src/de/wbem_class_de.rs
@@ -289,4 +289,24 @@ mod tests {
 
         assert!(lmhosts_service.PathName.is_some());
     }
+
+    #[test]
+    fn it_fail_to_desr_null_to_string() {
+        // Values can return as Null / Empty from WMI.
+        // It is impossible to `desr` such values to `String` (for example).
+        // See `it_desr_option_string` on how to fix this error.
+        let wmi_con = wmi_con();
+
+        #[derive(Deserialize, Debug)]
+        pub struct Win32_Service {
+            pub Name: String,
+            pub PathName: String,
+        }
+
+        let res: Result<Vec<Win32_Service>, _> = wmi_con.query();
+
+        let err = res.err().unwrap();
+
+        assert_eq!(format!("{}", err), "invalid type: Option value, expected a string")
+    }
 }

--- a/src/de/wbem_class_de.rs
+++ b/src/de/wbem_class_de.rs
@@ -262,4 +262,25 @@ mod tests {
             assert_eq!(res.Roles, ["LM_Workstation", "LM_Server", "NT"]);
         }
     }
+
+    #[test]
+    fn it_desr_option_string() {
+        let wmi_con = wmi_con();
+
+        #[derive(Deserialize, Debug)]
+        pub struct Win32_Service {
+            pub Name: String,
+            pub DisplayName: String,
+            pub PathName: Option<String>,
+            pub State: String,
+            pub Started: bool,
+        }
+
+        let results: Vec<Win32_Service> = wmi_con.query().unwrap();
+
+        for res in results {
+            assert_eq!(res.Name, "S");
+            assert_eq!(res.PathName, Some("a".to_owned()));
+        }
+    }
 }


### PR DESCRIPTION
Added support for Null/Empty values.

Before, trying to `desr` Null values will result in a correct error (see the test), but using `Option<String>` was not supported (see the image).

![image](https://user-images.githubusercontent.com/2358365/52913243-df216f80-32c4-11e9-8f93-8bedcf081422.png)


