### PR TITLE
Added ability to specify a namespace when creating a connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wmi"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Ohad Ravid <ohad.rv@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -98,7 +98,12 @@ impl WMIConnection {
     /// Creates a connection with the given namespace path.
     ///
     /// ```edition2018
-    /// let wmi_con = WMIConnection::with_namespace_path("ROOT\\Microsoft\\Windows\\Storage", com_con.into())?;
+    /// # fn main() -> Result<(), failure::Error> {
+    /// # use wmi::*;
+    /// # use serde::Deserialize;
+    /// let wmi_con = WMIConnection::with_namespace_path("ROOT\\Microsoft\\Windows\\Storage", COMLibrary::new()?.into())?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn with_namespace_path(namespace_path: &str, com_lib: Rc<COMLibrary>) -> Result<Self, Error> {
         let mut instance = Self {


### PR DESCRIPTION
I noticed that there was no way to specify a namespace when creating a WMIConnection and it always used to default ROOT\CIMV2. I had the need to use a different namespace so I figured I'd add support for it.