### PR TITLE
Added serde macro to Variant for clear JSON/Serialization

### DIFF
--- a/src/variant.rs
+++ b/src/variant.rs
@@ -5,11 +5,13 @@ use winapi::{
     shared::wtypes::*,
     um::{oaidl::SAFEARRAY, oaidl::VARIANT},
 };
+use serde::Serialize;
 
 // See: https://msdn.microsoft.com/en-us/library/cc237864.aspx
 const VARIANT_FALSE: i16 = 0x0000;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize)]
+#[serde(untagged)]
 pub enum Variant {
     Empty,
     Null,


### PR DESCRIPTION
I added derive macro to Variant enum. So we can translate our Vector<HashMap<String, Variant>> to Json directly.
Here some example for this:

`
let results: Vec<HashMap<String, Variant>> = wmi_con
    .raw_query("SELECT * FROM Win32_LogicalDisk")
    .unwrap();
let json = serde_json::to_string(&results).unwrap();
`