### PR TITLE
Use BSTRs as expected by WMI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default-target = "x86_64-pc-windows-msvc"
 test = ["lazy_static"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3.9", features = ["objbase", "wbemcli", "objidlbase", "oaidl", "oleauto", "errhandlingapi"] }
+winapi = { version = "0.3.9", features = ["objbase", "wbemcli", "objidlbase", "oaidl", "oleauto", "errhandlingapi", "wtypes", "wtypesbase"] }
 log = "0.4"
 widestring = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/bstr.rs
+++ b/src/bstr.rs
@@ -1,5 +1,6 @@
 use crate::WMIError;
 use winapi::{
+    shared::ntdef::LPCWSTR,
     shared::wtypes::BSTR,
     shared::wtypesbase::OLECHAR,
     um::oleauto::*,
@@ -31,6 +32,10 @@ impl BStr {
     }
 
     pub fn as_bstr(&self) -> BSTR {
+        self.0.as_ptr()
+    }
+
+    pub fn as_lpcwstr(&self) -> LPCWSTR {
         self.0.as_ptr()
     }
 }

--- a/src/bstr.rs
+++ b/src/bstr.rs
@@ -1,0 +1,36 @@
+use crate::WMIError;
+use winapi::{
+    shared::wtypes::BSTR,
+    shared::wtypesbase::OLECHAR,
+    um::oleauto::*,
+};
+use std::convert::TryFrom;
+use std::ptr::{null, NonNull};
+
+/// A non-null [BSTR]
+///
+/// [BSTR]:         https://docs.microsoft.com/en-us/previous-versions/windows/desktop/automat/bstr
+pub(crate) struct BStr(NonNull<OLECHAR>);
+
+impl std::ops::Drop for BStr {
+    fn drop(&mut self) {
+        unsafe { SysFreeString(self.as_bstr()) }
+    }
+}
+
+impl BStr {
+    pub fn from_str(s: &str) -> Result<Self, WMIError> {
+        let len = s.encode_utf16().count();
+        let len32 = u32::try_from(len).map_err(|_| WMIError::ConvertLengthError(len as _))?;
+
+        let bstr = BStr(NonNull::new(unsafe { SysAllocStringLen(null(), len32) }).ok_or(WMIError::ConvertAllocateError)?);
+        for (i, cu) in s.encode_utf16().enumerate() {
+            unsafe { std::ptr::write(bstr.0.as_ptr().add(i), cu) };
+        }
+        Ok(bstr)
+    }
+
+    pub fn as_bstr(&self) -> BSTR {
+        self.0.as_ptr()
+    }
+}

--- a/src/bstr.rs
+++ b/src/bstr.rs
@@ -7,13 +7,14 @@ use winapi::{
 };
 use std::convert::TryFrom;
 use std::ptr::{null, NonNull};
+use std::ops::Drop;
 
 /// A non-null [BSTR]
 ///
 /// [BSTR]:         https://docs.microsoft.com/en-us/previous-versions/windows/desktop/automat/bstr
 pub(crate) struct BStr(NonNull<OLECHAR>);
 
-impl std::ops::Drop for BStr {
+impl Drop for BStr {
     fn drop(&mut self) {
         unsafe { SysFreeString(self.as_bstr()) }
     }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,9 +1,9 @@
+use crate::BStr;
 use crate::utils::{check_hres, WMIError};
 use log::debug;
 use std::ptr;
 use std::ptr::NonNull;
 use std::rc::Rc;
-use widestring::WideCString;
 use winapi::{
     shared::{
         ntdef::NULL,
@@ -193,11 +193,11 @@ impl WMIConnection {
 
         let mut p_svc = ptr::null_mut::<IWbemServices>();
 
-        let object_path_bstr = WideCString::from_str(path)?;
+        let object_path_bstr = BStr::from_str(path)?;
 
         unsafe {
             check_hres((*self.loc()).ConnectServer(
-                object_path_bstr.as_ptr() as *mut _,
+                object_path_bstr.as_bstr(),
                 ptr::null_mut(),
                 ptr::null_mut(),
                 ptr::null_mut(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,7 @@
 #![allow(unused_unsafe)]
 #![cfg(windows)]
 
+mod bstr;
 pub mod connection;
 pub mod datetime;
 pub mod de;
@@ -116,6 +117,7 @@ pub mod variant;
 #[cfg(any(test, feature = "test"))]
 pub mod tests;
 
+use bstr::BStr;
 pub use connection::{COMLibrary, WMIConnection};
 pub use datetime::WMIDateTime;
 pub use duration::WMIDuration;

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,3 +1,4 @@
+use crate::BStr;
 use crate::de::wbem_class_de::from_wbem_class_obj;
 use crate::result_enumerator::{IWbemClassWrapper, QueryResultEnumerator};
 use crate::{
@@ -8,7 +9,6 @@ use serde::de;
 use std::collections::HashMap;
 use std::ptr;
 use std::ptr::NonNull;
-use widestring::WideCString;
 use winapi::um::wbemcli::IWbemClassObject;
 use winapi::{
     shared::ntdef::NULL,
@@ -132,15 +132,15 @@ impl WMIConnection {
         &self,
         query: impl AsRef<str>,
     ) -> Result<QueryResultEnumerator, WMIError> {
-        let query_language = WideCString::from_str("WQL")?;
-        let query = WideCString::from_str(query)?;
+        let query_language = BStr::from_str("WQL")?;
+        let query = BStr::from_str(query.as_ref())?;
 
         let mut p_enumerator = NULL as *mut IEnumWbemClassObject;
 
         unsafe {
             check_hres((*self.svc()).ExecQuery(
-                query_language.as_ptr() as *mut _,
-                query.as_ptr() as *mut _,
+                query_language.as_bstr(),
+                query.as_bstr(),
                 (WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY) as i32,
                 ptr::null_mut(),
                 &mut p_enumerator,
@@ -279,13 +279,13 @@ impl WMIConnection {
         &self,
         object_path: impl AsRef<str>,
     ) -> Result<IWbemClassWrapper, WMIError> {
-        let object_path = WideCString::from_str(object_path.as_ref())?;
+        let object_path = BStr::from_str(object_path.as_ref())?;
 
         let mut pcls_obj = NULL as *mut IWbemClassObject;
 
         unsafe {
             check_hres((*self.svc()).GetObject(
-                object_path.as_ptr() as *mut _,
+                object_path.as_bstr(),
                 WBEM_FLAG_RETURN_WBEM_COMPLETE as i32,
                 ptr::null_mut(),
                 &mut pcls_obj,

--- a/src/result_enumerator.rs
+++ b/src/result_enumerator.rs
@@ -67,7 +67,7 @@ impl IWbemClassWrapper {
 
         unsafe {
             (*self.inner.unwrap().as_ptr()).Get(
-                name_prop.as_bstr(),
+                name_prop.as_lpcwstr(),
                 0,
                 &mut vt_prop,
                 ptr::null_mut(),

--- a/src/result_enumerator.rs
+++ b/src/result_enumerator.rs
@@ -1,5 +1,6 @@
 use crate::de::wbem_class_de::from_wbem_class_obj;
 use crate::{
+    BStr,
     connection::WMIConnection, safearray::safe_array_to_vec_of_strings, utils::check_hres, Variant,
     WMIError,
 };
@@ -7,7 +8,6 @@ use log::trace;
 use serde::de;
 use std::convert::TryInto;
 use std::{mem, ptr, ptr::NonNull};
-use widestring::WideCString;
 use winapi::um::oaidl::VARIANT;
 use winapi::um::oleauto::VariantClear;
 use winapi::{
@@ -61,14 +61,13 @@ impl IWbemClassWrapper {
     }
 
     pub fn get_property(&self, property_name: &str) -> Result<Variant, WMIError> {
-        let name_prop =
-            WideCString::from_str(property_name)?;
+        let name_prop = BStr::from_str(property_name)?;
 
         let mut vt_prop: VARIANT = unsafe { mem::zeroed() };
 
         unsafe {
             (*self.inner.unwrap().as_ptr()).Get(
-                name_prop.as_ptr() as *mut _,
+                name_prop.as_bstr(),
                 0,
                 &mut vt_prop,
                 ptr::null_mut(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 use winapi::shared::{ntdef::HRESULT, wtypes::VARTYPE};
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum WMIError {
     #[error("HRESULT Call failed with: {hres:#X}")]
     HResultError { hres: HRESULT },
@@ -25,6 +26,10 @@ pub enum WMIError {
     ConvertDatetimeError(String),
     #[error("Expected {0:?} to be at 25 chars")]
     ConvertDurationError(String),
+    #[error("Length {0} was too long to convert")]
+    ConvertLengthError(u64),
+    #[error("Failed to allocate")]
+    ConvertAllocateError,
     #[error("{0}")]
     SerdeError(String),
     #[error(transparent)]


### PR DESCRIPTION
So, notes:

* I got rid of widestring for passing values into WMI, including in one case where widestring might've technically been fine.
* I've kept widestring for reading values *from* WMI.  I could extend BStr a little more to eliminate the dependency entirely if that's desirable though.
* I've kept BStr hidden / crate-local, unlike other types & methods of this crate.  If you'd rather it be `pub` like all the rest, just let me know!

Closes https://github.com/ohadravid/wmi-rs/issues/25