### PR TITLE
CIMTYPE support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wmi"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Ohad Ravid <ohad.rv@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ WMI (Windows Management Instrumentation) crate for rust.
 ```toml
 # Cargo.toml
 [dependencies]
-wmi = "0.8"
+wmi = "0.9"
 ```
 
 
@@ -63,7 +63,7 @@ This crate provides async methods under the `async-query` flag:
 ```toml
 # Cargo.toml
 [dependencies]
-wmi = { version = "0.8", features = ["async-query"] }
+wmi = { version = "0.9", features = ["async-query"] }
 ```
 
 The methods become available on `WMIConnection`

--- a/src/de/variant_de.rs
+++ b/src/de/variant_de.rs
@@ -113,17 +113,17 @@ impl<'de> Deserialize<'de> for Variant {
             fn visit_i16<E>(self, value: i16) -> Result<Self::Value, E> {
                 Ok(Variant::I2(value))
             }
-            
+
             #[inline]
             fn visit_u16<E>(self, value: u16) -> Result<Self::Value, E> {
                 Ok(Variant::UI2(value))
             }
-            
+
             #[inline]
             fn visit_i8<E>(self, value: i8) -> Result<Self::Value, E> {
                 Ok(Variant::I1(value))
             }
-            
+
             #[inline]
             fn visit_u8<E>(self, value: u8) -> Result<Self::Value, E> {
                 Ok(Variant::UI1(value))

--- a/src/de/variant_de.rs
+++ b/src/de/variant_de.rs
@@ -100,6 +100,36 @@ impl<'de> Deserialize<'de> for Variant {
             }
 
             #[inline]
+            fn visit_i32<E>(self, value: i32) -> Result<Self::Value, E> {
+                Ok(Variant::I4(value))
+            }
+
+            #[inline]
+            fn visit_u32<E>(self, value: u32) -> Result<Self::Value, E> {
+                Ok(Variant::UI4(value))
+            }
+
+            #[inline]
+            fn visit_i16<E>(self, value: i16) -> Result<Self::Value, E> {
+                Ok(Variant::I2(value))
+            }
+            
+            #[inline]
+            fn visit_u16<E>(self, value: u16) -> Result<Self::Value, E> {
+                Ok(Variant::UI2(value))
+            }
+            
+            #[inline]
+            fn visit_i8<E>(self, value: i8) -> Result<Self::Value, E> {
+                Ok(Variant::I1(value))
+            }
+            
+            #[inline]
+            fn visit_u8<E>(self, value: u8) -> Result<Self::Value, E> {
+                Ok(Variant::UI1(value))
+            }
+
+            #[inline]
             fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E> {
                 Ok(Variant::R8(value))
             }

--- a/src/de/wbem_class_de.rs
+++ b/src/de/wbem_class_de.rs
@@ -10,8 +10,6 @@ use crate::result_enumerator::IWbemClassWrapper;
 use crate::WMIError;
 
 pub struct Deserializer<'a> {
-    // This string starts with the input data and characters are truncated off
-    // the beginning as data is parsed.
     pub wbem_class_obj: &'a IWbemClassWrapper,
 }
 

--- a/src/result_enumerator.rs
+++ b/src/result_enumerator.rs
@@ -76,16 +76,19 @@ impl IWbemClassWrapper {
 
         let mut vt_prop: VARIANT = unsafe { mem::zeroed() };
 
+        let mut cim_type = 0;
+
         unsafe {
             check_hres((*self.inner.as_ptr()).Get(
                 name_prop.as_lpcwstr(),
                 0,
                 &mut vt_prop,
-                ptr::null_mut(),
+                &mut cim_type,
                 ptr::null_mut(),
             ))?;
 
-            let property_value = Variant::from_variant(vt_prop)?;
+            let property_value =
+                Variant::from_variant(vt_prop)?.convert_into_cim_type(cim_type as _)?;
 
             check_hres(VariantClear(&mut vt_prop))?;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,6 +11,8 @@ pub enum WMIError {
     #[error(transparent)]
     ParseIntError(#[from] std::num::ParseIntError),
     #[error(transparent)]
+    ParseFloatError(#[from] std::num::ParseFloatError),
+    #[error(transparent)]
     ParseDatetimeError(#[from] chrono::format::ParseError),
     #[error("Converting from variant type {0:#X} is not implemented yet")]
     ConvertError(VARTYPE),


### PR DESCRIPTION
Following #35, I found out that according to the [docs](https://docs.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemclassobject-get) for the `IWbemClassObject::Get` method:
> If the type of the property is ..., then the returned values in the VARIANT do not contain enough information to identify the true type. The **pvtType** out parameter indicates this.

Also according to [this](https://social.msdn.microsoft.com/Forums/en-US/70d136db-93bf-4faa-9b0b-090175a98bb5/wmi-does-not-seem-to-work-with-uint64-types?forum=vcgeneral):
> In particular, it seems _all_ uint64 types, many unint32 and some unint16 types are returned as strings.


This PR adds the needed conversion, so that the correct types are returned.


@vnagarnaik could you checkout & see if you get the expected results now? On my machine I get:
```
$ cargo run "SELECT AdapterRAM FROM Win32_VideoController"
   Compiling wmi v0.9.0 (C:\Workspace\wmi-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 1.97s
     Running `target\debug\wmiq.exe "SELECT AdapterRAM FROM Win32_VideoController"`
Result 0
{
    "AdapterRAM": UI4(
        1073741824,
    ),
}
```
which seems correct according to the [docs](https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-videocontroller).