### PR TITLE
Feat: use time crate instead of chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,24 @@ keywords = ["wmi", "com", "win32"]
 default-target = "x86_64-pc-windows-msvc"
 
 [features]
+default = ["chrono"]
+
 test = ["lazy_static", "async-std"]
 async-query = ["async-channel", "futures", "com"]
+# Make WMIDateTime use `time::OffsetDateTime` instead of `chrono::DateTime`
+# Note: this **replaces** the `chrono` dep with the `time`.
+# The default is using `chrono`.
+# It is a compile-time error to not have either the default or this feature active.
+time-instead-of-chrono = ["time"]
+
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = ["objbase", "wbemcli", "objidlbase", "oaidl", "oleauto", "errhandlingapi", "wtypes", "wtypesbase"] }
 log = "0.4"
 widestring = "0.5"
 serde = { version = "1.0", features = ["derive"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"], optional = true }
+time = { version = "0.3", features = ["formatting", "parsing", "macros", "serde"], optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 thiserror = "^1"
 async-channel = {version = "1.6", optional = true}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,11 +29,21 @@ steps:
     displayName: Install rust (windows)
     condition: eq( variables['Agent.OS'], 'Windows_NT' )
 
+  # Build time crate
   - script: cargo build --all-features
-    displayName: Cargo build
+    displayName: Cargo build - Use time
+  
+  # Build chrono
+  - script: cargo build --features=test,async-query
+    displayName: Cargo build - Use chrono
 
+  # Test time crate
   - script: cargo test --all-features
-    displayName: Cargo test
+    displayName: Cargo test - Use time
+
+  # Test chrono
+  - script: cargo test --features=test,async-query
+    displayName: Cargo test - Use chrono
 
   - script: |
       cargo publish

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1,30 +1,87 @@
 use super::WMIError;
-use chrono::prelude::*;
 use serde::{de, ser};
 use std::fmt;
 use std::str::FromStr;
 
-/// A wrapper type around chrono's DateTime, which supports parsing from WMI-format strings.
-///
+#[cfg(all(not(feature = "time-instead-of-chrono"), not(feature = "default")))]
+std::compile_error!("wmi::datetime::WMIDateTime must be available: either use the 'default' or 'time-instead-of-chrono' feature");
+
+#[cfg(not(feature = "time-instead-of-chrono"))]
+use chrono::prelude::*;
+
+#[cfg(feature = "time-instead-of-chrono")]
+use time::{
+    format_description::{well_known::Rfc3339, FormatItem},
+    macros::format_description,
+    parsing::Parsed,
+    PrimitiveDateTime, UtcOffset,
+};
+
+/// A wrapper type around `chrono`'s `DateTime` (`time`'s `OffsetDateTime` if the
+// `time-instead-of-chrono` feature is active), which supports parsing from WMI-format strings.
 #[derive(Debug)]
-pub struct WMIDateTime(pub DateTime<FixedOffset>);
+pub struct WMIDateTime(
+    #[cfg(not(feature = "time-instead-of-chrono"))] pub chrono::DateTime<FixedOffset>,
+    #[cfg(feature = "time-instead-of-chrono")] pub time::OffsetDateTime,
+);
 
 impl FromStr for WMIDateTime {
     type Err = WMIError;
 
+    #[cfg(not(feature = "time-instead-of-chrono"))]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.len() < 21 {
             return Err(WMIError::ConvertDatetimeError(s.into()));
         }
 
         let (datetime_part, tz_part) = s.split_at(21);
-
         let tz_min: i32 = tz_part.parse()?;
-
         let tz = FixedOffset::east(tz_min * 60);
-
         let dt = tz.datetime_from_str(datetime_part, "%Y%m%d%H%M%S.%f")?;
 
+        Ok(Self(dt))
+    }
+
+    #[cfg(feature = "time-instead-of-chrono")]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() < 21 {
+            return Err(WMIError::ConvertDatetimeError(s.into()));
+        }
+
+        // We have to ignore the year here, see bottom of https://time-rs.github.io/book/api/format-description.html
+        // about the large-dates feature (permanent link:
+        // https://github.com/time-rs/book/blob/0476c5bb35b512ac0cbda5c6cd5f0d0628b0269e/src/api/format-description.md?plain=1#L205)
+        const TIME_FORMAT: &[FormatItem<'static>] =
+            format_description!("[month][day][hour][minute][second].[subsecond digits:6]");
+
+        let minutes_offset = s[21..].parse::<i32>()?;
+        let offset =
+            UtcOffset::from_whole_seconds(minutes_offset * 60).map_err(time::Error::from)?;
+
+        let mut parser = Parsed::new();
+
+        let naive_date_time = &s[4..21];
+        parser
+            .parse_items(naive_date_time.as_bytes(), TIME_FORMAT)
+            .map_err(time::Error::from)?;
+        // Microsoft thinks it is okay to return a subsecond value in microseconds but not put the zeros before it
+        // so 1.1 is 1 second and 100 microsecond, ergo 1.000100 ...
+        parser
+            .set_subsecond(parser.subsecond().unwrap_or(0) / 1000)
+            .ok_or_else(|| {
+                WMIError::ParseDatetimeError(
+                    time::error::Format::InvalidComponent("subsecond").into(),
+                )
+            })?;
+
+        let naive_year = s[..4].parse::<i32>()?;
+        parser.set_year(naive_year).ok_or_else(|| {
+            WMIError::ParseDatetimeError(time::error::Format::InvalidComponent("year").into())
+        })?;
+
+        let naive_date_time: PrimitiveDateTime =
+            std::convert::TryInto::try_into(parser).map_err(time::Error::from)?;
+        let dt = naive_date_time.assume_offset(offset);
         Ok(Self(dt))
     }
 }
@@ -60,7 +117,13 @@ impl ser::Serialize for WMIDateTime {
     where
         S: ser::Serializer,
     {
-        serializer.serialize_str(&self.0.to_rfc3339())
+        #[cfg(not(feature = "time-instead-of-chrono"))]
+        let formatted = self.0.to_rfc3339();
+        // Unwrap: we passed a well known format, if it fails something has gone very wrong
+        #[cfg(feature = "time-instead-of-chrono")]
+        let formatted = self.0.format(&Rfc3339).unwrap();
+
+        serializer.serialize_str(&formatted)
     }
 }
 
@@ -68,19 +131,31 @@ impl ser::Serialize for WMIDateTime {
 mod tests {
     use super::WMIDateTime;
     use serde_json;
+    #[cfg(feature = "time-instead-of-chrono")]
+    use time::format_description::well_known::Rfc3339;
 
     #[test]
     fn it_works_with_negative_offset() {
         let dt: WMIDateTime = "20190113200517.500000-180".parse().unwrap();
 
-        assert_eq!(dt.0.to_rfc3339(), "2019-01-13T20:05:17.000500-03:00");
+        #[cfg(not(feature = "time-instead-of-chrono"))]
+        let formatted = dt.0.to_rfc3339();
+        #[cfg(feature = "time-instead-of-chrono")]
+        let formatted = dt.0.format(&Rfc3339).unwrap();
+
+        assert_eq!(formatted, "2019-01-13T20:05:17.000500-03:00");
     }
 
     #[test]
     fn it_works_with_positive_offset() {
         let dt: WMIDateTime = "20190113200517.500000+060".parse().unwrap();
 
-        assert_eq!(dt.0.to_rfc3339(), "2019-01-13T20:05:17.000500+01:00");
+        #[cfg(not(feature = "time-instead-of-chrono"))]
+        let formatted = dt.0.to_rfc3339();
+        #[cfg(feature = "time-instead-of-chrono")]
+        let formatted = dt.0.format(&Rfc3339).unwrap();
+
+        assert_eq!(formatted, "2019-01-13T20:05:17.000500+01:00");
     }
 
     #[test]

--- a/src/de/meta.rs
+++ b/src/de/meta.rs
@@ -132,7 +132,9 @@ mod tests {
     fn it_works() {
         #[derive(Deserialize, Debug)]
         struct Win32_OperatingSystem {
+            #[allow(dead_code)]
             Caption: String,
+            #[allow(dead_code)]
             Name: String,
         }
 
@@ -148,7 +150,9 @@ mod tests {
         #[serde(rename = "Win32_OperatingSystem")]
         #[serde(rename_all = "PascalCase")]
         struct Win32OperatingSystem {
+            #[allow(dead_code)]
             caption: String,
+            #[allow(dead_code)]
             name: String,
         }
 
@@ -167,6 +171,7 @@ mod tests {
         #[derive(Deserialize, Debug)]
         struct EvilFieldName {
             #[serde(rename = "Evil\"Field\"Name")]
+            #[allow(dead_code)]
             field: String,
         }
 

--- a/src/de/wbem_class_de.rs
+++ b/src/de/wbem_class_de.rs
@@ -269,7 +269,7 @@ mod tests {
             assert_eq!(w.EncryptionLevel, 256);
             assert_eq!(w.ForegroundApplicationBoost, 2);
             assert_eq!(
-                w.LastBootUpTime.0.timezone().local_minus_utc() / 60,
+                w.LastBootUpTime.0.offset().whole_seconds() / 60,
                 w.CurrentTimeZone as i32
             );
         }

--- a/src/de/wbem_class_de.rs
+++ b/src/de/wbem_class_de.rs
@@ -268,8 +268,14 @@ mod tests {
             assert_eq!(w.Debug, false);
             assert_eq!(w.EncryptionLevel, 256);
             assert_eq!(w.ForegroundApplicationBoost, 2);
+            
+            #[cfg(not(feature = "time-instead-of-chrono"))]
+            let last_boot_up_time = w.LastBootUpTime.0.timezone().local_minus_utc() / 60;
+            #[cfg(feature = "time-instead-of-chrono")]
+            let last_boot_up_time = w.LastBootUpTime.0.offset().whole_seconds() / 60;
+
             assert_eq!(
-                w.LastBootUpTime.0.offset().whole_seconds() / 60,
+                last_boot_up_time,
                 w.CurrentTimeZone as i32
             );
         }

--- a/src/query.rs
+++ b/src/query.rs
@@ -594,6 +594,7 @@ mod tests {
 
         #[derive(Deserialize, Debug)]
         struct Win32_OperatingSystem {
+            #[allow(dead_code)]
             NoSuchField: String,
         }
 
@@ -606,6 +607,7 @@ mod tests {
     fn it_builds_correct_query_without_filters() {
         #[derive(Deserialize, Debug)]
         struct Win32_OperatingSystem {
+            #[allow(dead_code)]
             Caption: String,
         }
 
@@ -619,6 +621,7 @@ mod tests {
     fn it_builds_correct_query() {
         #[derive(Deserialize, Debug)]
         struct Win32_OperatingSystem {
+            #[allow(dead_code)]
             Caption: String,
         }
 
@@ -767,6 +770,7 @@ mod tests {
         #[derive(Deserialize, Debug)]
         struct Win32_DiskDrive {
             __Path: String,
+            #[allow(dead_code)]
             Caption: String,
         }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,8 +12,12 @@ pub enum WMIError {
     ParseIntError(#[from] std::num::ParseIntError),
     #[error(transparent)]
     ParseFloatError(#[from] std::num::ParseFloatError),
+    #[cfg(not(feature = "time-instead-of-chrono"))]
     #[error(transparent)]
     ParseDatetimeError(#[from] chrono::format::ParseError),
+    #[cfg(feature = "time-instead-of-chrono")]
+    #[error(transparent)]
+    ParseDatetimeError(#[from] time::Error),
     #[error("Converting from variant type {0:#X} is not implemented yet")]
     ConvertError(VARTYPE),
     #[error("{0}")]


### PR DESCRIPTION
The chrono crate has not fixed a CVE for months now, while the
time crate has. chrono is also using an outdated version of
time and this updates it (0.1 -> 0.3).

For people that use `cargo-deny` or that prefer time, offer the option
to use it as the date backend for the `WMIDateTime` type.

Note: this **can be** breaking change since the time is part of the
part of the public interface through `WMIDateTime`: if `default-features = false` 
is active, the crate will now fail to compile where it would not before. There is a
compile time error pointing to the fix.