### PR TITLE
Use WMI's "native" async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ serde_json = { version = "1.0" }
 criterion = "0.3"
 tempdir = "0.3"
 async-std = { version = "1.10",  features = ["attributes"] }
+tokio = { version = "1.20.0", features = ["rt", "macros"] }
 
 [[bin]]
 name = "wmiq"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wmi"
-version = "0.9.3"
+version = "0.10.0"
 authors = ["Ohad Ravid <ohad.rv@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -22,8 +22,9 @@ default-target = "x86_64-pc-windows-msvc"
 default = ["chrono"]
 # Use { default-features = false, features = ["time"] } to use `time` instead of `chrono`.
 
-test = ["lazy_static", "async-std"]
-async-query = ["async-channel", "futures", "com"]
+test = ["lazy_static"]
+# Deprecated. async support is always enabled.
+async-query = []
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = ["objbase", "wbemcli", "objidlbase", "oaidl", "oleauto", "errhandlingapi", "wtypes", "wtypesbase"] }
@@ -34,10 +35,8 @@ chrono = { version = "0.4", features = ["serde"], optional = true }
 time = { version = "0.3", features = ["formatting", "parsing", "macros", "serde"], optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 thiserror = "^1"
-async-channel = {version = "1.6", optional = true}
-async-std = { version = "1.10",  features = ["attributes"], optional = true }
-futures = { version = "0.3", optional = true}
-com = { version = "0.6", features = ["production"], optional = true }
+futures = { version = "0.3" }
+com = { version = "0.6", features = ["production"] }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ WMI (Windows Management Instrumentation) crate for rust.
 ```toml
 # Cargo.toml
 [dependencies]
-wmi = "0.9"
+wmi = "0.10"
 ```
 
 
@@ -60,7 +60,7 @@ If you prefer to use the `time` crate instead of the default `chrono`, include `
 
 ```toml
 [dependencies]
-wmi-rs = { version = "0.9", default-features = false, features = ["time"] }
+wmi-rs = { version = "0.10", default-features = false, features = ["time"] }
 ```
 
 and use the `WMIOffsetDateTime` wrapper instead of the the `WMIDateTime` wrapper.
@@ -69,15 +69,6 @@ and use the `WMIOffsetDateTime` wrapper instead of the the `WMIDateTime` wrapper
 
 WMI supports async queries, with methods like [ExecAsyncQuery](https://docs.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemservices-execqueryasync).
 
-This crate provides async methods under the `async-query` flag:
-
-```toml
-# Cargo.toml
-[dependencies]
-wmi = { version = "0.9", features = ["async-query"] }
-```
-
-The methods become available on `WMIConnection`
 
 ```rust
 #![allow(non_camel_case_types)]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,11 +42,11 @@ steps:
     displayName: Cargo build - All features
     
   # Test time crate
-  - script: cargo test --no-default-features --features=time,async-query
+  - script: cargo test --no-default-features --features=time
     displayName: Cargo test - Use time
 
   # Test chrono
-  - script: cargo test --no-default-features --features=chrono,async-query
+  - script: cargo test --no-default-features --features=chrono
     displayName: Cargo test - Use chrono
 
   - script: |

--- a/src/async_query.rs
+++ b/src/async_query.rs
@@ -29,7 +29,7 @@ impl WMIConnection {
 
         let stream = AsyncQueryResultStream::new();
         // The internal RefCount has initial value = 1.
-        let p_sink: ClassAllocation<QuerySink> = QuerySink::allocate(Some(stream.clone()));
+        let p_sink: ClassAllocation<QuerySink> = QuerySink::allocate(stream.clone());
         let p_sink_handle = IWbemObjectSink::from(&**p_sink);
 
         unsafe {

--- a/src/de/wbem_class_de.rs
+++ b/src/de/wbem_class_de.rs
@@ -244,7 +244,7 @@ mod tests {
         struct Win32_OperatingSystem {
             Caption: String,
             Name: String,
-            
+
             CurrentTimeZone: i16,
             Debug: bool,
 
@@ -254,7 +254,7 @@ mod tests {
 
             #[cfg(feature = "chrono")]
             LastBootUpTime: crate::WMIDateTime,
-            
+
             #[cfg(all(feature = "time", not(feature = "chrono")))]
             LastBootUpTime: crate::WMIOffsetDateTime,
         }
@@ -274,7 +274,7 @@ mod tests {
             assert_eq!(w.EncryptionLevel, 256);
             assert_eq!(w.ForegroundApplicationBoost, 2);
             assert_ne!(w.CurrentTimeZone, i16::max_value());
-            
+
             #[cfg(any(feature = "time", feature = "chrono"))]
             assert!(w.LastBootUpTime.0.to_string().starts_with("20"));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,10 +178,8 @@ pub mod safearray;
 pub mod utils;
 pub mod variant;
 
-#[cfg(feature = "async-query")]
 pub mod async_query;
 // Keep QuerySink implementation private
-#[cfg(feature = "async-query")]
 pub(crate) mod query_sink;
 
 #[cfg(any(test, feature = "test"))]
@@ -202,5 +200,5 @@ pub use utils::{WMIError, WMIResult};
 pub use variant::Variant;
 
 #[doc = include_str!("../README.md")]
-#[cfg(all(doctest, feature = "async-query", feature = "chrono"))]
+#[cfg(all(doctest, feature = "chrono"))]
 pub struct ReadmeDoctests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,12 +107,7 @@
 //!
 //! # Async Query
 //!
-//! Async queries are available behind the feature flag `async-query`.
-//! In Cargo.toml:
-//! ```toml
-//! wmi = { version = "x.y.z",  features = ["async-query"] }
-//! ```
-//! You now have access to additional methods on [`WMIConnection`](WMIConnection#additional-async-methods).
+//! Async queries use WMI's native async support (but a runtime like `tokio`, `async-std` or `futures::executor::block_on` is still required).
 //!
 //! ```edition2018
 //! # use futures::executor::block_on;

--- a/src/query_sink.rs
+++ b/src/query_sink.rs
@@ -65,6 +65,11 @@ impl AsyncQueryResultStreamImpl {
     }
 }
 
+/// A stream of WMI query results.
+/// We use a mutex to synchronize the consumer and the calls from the WMI-managed thread.
+/// A blocking mutex is used because we want to be runtime agnostic
+/// and because according to [`tokio::sync::Mutex`](https://docs.rs/tokio/tokio/tokio/sync/struct.Mutex.html):
+/// > The primary use case for the async mutex is to provide shared mutable access to IO resources such as a database connection. If the value behind the mutex is just data, it’s usually appropriate to use a blocking mutex
 #[derive(Debug, Default, Clone)]
 pub struct AsyncQueryResultStream(Arc<Mutex<AsyncQueryResultStreamImpl>>);
 
@@ -204,7 +209,7 @@ mod tests {
     use winapi::shared::ntdef::NULL;
 
     #[async_std::test]
-    async fn async_it_should_use_async_channel_to_send_result() {
+    async fn async_it_should_send_result() {
         let con = wmi_con();
         let mut stream = AsyncQueryResultStream::new();
         let sink = QuerySink::allocate(Some(stream.clone()));


### PR DESCRIPTION
Instead of using async channels & forcing the use of async-std, this PR changes the async query to use the "native" WMI async flow which matches very closely to the `Waker` [API](https://rust-lang.github.io/async-book/02_execution/03_wakeups.html).

Because this API is the basic building block of the Rust async, all runtimes will now work "natively".
