### PR TITLE
deps: update widestring to version 1+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ async-query = ["async-channel", "futures", "com"]
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = ["objbase", "wbemcli", "objidlbase", "oaidl", "oleauto", "errhandlingapi", "wtypes", "wtypesbase"] }
 log = "0.4"
-widestring = "0.5"
+widestring = "1"
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"], optional = true }
 time = { version = "0.3", features = ["formatting", "parsing", "macros", "serde"], optional = true }


### PR DESCRIPTION

This will need a minor version update (not patch) since a type from `widestring` is used in the public interface
through the `wmi::utils::WMIError` type