### PR TITLE
Stop calling `CoUninitialize`, make `COMLibrary: Copy + !Send`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wmi"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Ohad Ravid <ohad.rv@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ WMI (Windows Management Instrumentation) crate for rust.
 ```toml
 # Cargo.toml
 [dependencies]
-wmi = "0.10"
+wmi = "0.11"
 ```
 
 
@@ -60,7 +60,7 @@ If you prefer to use the `time` crate instead of the default `chrono`, include `
 
 ```toml
 [dependencies]
-wmi-rs = { version = "0.10", default-features = false, features = ["time"] }
+wmi-rs = { version = "0.11", default-features = false, features = ["time"] }
 ```
 
 and use the `WMIOffsetDateTime` wrapper instead of the the `WMIDateTime` wrapper.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,13 +3,11 @@ use crate::WMIConnection;
 
 pub mod fixtures {
     use super::*;
-    use lazy_static::lazy_static;
-
     // This way we only setup COM security once during tests.
     // We can't use `std::sync::Once` because we have to keep the `COM_LIB` object alive for the
     // entire run.
-    lazy_static! {
-        static ref COM_LIB: COMLibrary = COMLibrary::new().unwrap();
+    thread_local! {
+        static COM_LIB: COMLibrary = COMLibrary::new().unwrap();
     }
 
     pub fn wmi_con() -> WMIConnection {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,15 +3,15 @@ use crate::WMIConnection;
 
 pub mod fixtures {
     use super::*;
-    // This way we only setup COM security once during tests.
-    // We can't use `std::sync::Once` because we have to keep the `COM_LIB` object alive for the
-    // entire run.
+    // This way we only setup COM security once per thread during tests.
     thread_local! {
-        static COM_LIB: COMLibrary = COMLibrary::new().unwrap();
+        static COM_LIB: COMLibrary = COMLibrary::without_security().unwrap();
     }
 
     pub fn wmi_con() -> WMIConnection {
-        let wmi_con = WMIConnection::new(COMLibrary::without_security().unwrap().into()).unwrap();
+        let com_lib = COM_LIB.with(|com| *com);
+
+        let wmi_con = WMIConnection::new(com_lib).unwrap();
 
         wmi_con
     }


### PR DESCRIPTION
Closes #39, by never calling `CoUninitialize`.
Also fixes a bug where `COMLibrary` was `Send`, and so could be moved to a different thread where COM was not actually initialized. 
Initializing `WMIConnection` is now done directly with `COMLibrary` (and not an `Rc<COMLibrary>`).