### PR TITLE
Support for Event notifications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ criterion = "0.4"
 tempdir = "0.3"
 async-std = { version = "1.10",  features = ["attributes"] }
 tokio = { version = "1.20.0", features = ["rt", "macros"] }
+sys-locale = "0.2.1"
 
 [[bin]]
 name = "wmiq"

--- a/src/async_query.rs
+++ b/src/async_query.rs
@@ -1,16 +1,17 @@
-use crate::query_sink::{AsyncQueryResultStream, IWbemObjectSink, QuerySink};
-use crate::result_enumerator::IWbemClassWrapper;
-use crate::{connection::WMIConnection, utils::check_hres, WMIResult};
 use crate::{
-    query::{build_query, FilterValue},
+    query_sink::{AsyncQueryResultStream, IWbemObjectSink, QuerySink},
+    query::{FilterValue, build_query},
+    result_enumerator::IWbemClassWrapper,
+    connection::WMIConnection,
+    utils::check_hres,
+    WMIResult,
     BStr,
 };
-use com::production::ClassAllocation;
-use com::AbiTransferable;
+use com::{production::ClassAllocation, AbiTransferable};
 use futures::stream::{Stream, StreamExt, TryStreamExt};
-use serde::de;
 use std::{collections::HashMap, ptr};
 use winapi::um::wbemcli::WBEM_FLAG_BIDIRECTIONAL;
+use serde::de;
 
 ///
 /// ### Additional async methods
@@ -56,13 +57,13 @@ impl WMIConnection {
     /// # use wmi::*;
     /// # use std::collections::HashMap;
     /// # use futures::executor::block_on;
-    /// # fn main() -> Result<(), wmi::WMIError> {
+    /// # fn main() -> wmi::WMIResult<()> {
     /// #   block_on(exec_async_query())?;
     /// #   Ok(())
     /// # }
     /// #
     /// # async fn exec_async_query() -> WMIResult<()> {
-    /// # let con = WMIConnection::new(COMLibrary::new()?.into())?;
+    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
     /// use futures::stream::TryStreamExt;
     /// let results: Vec<HashMap<String, Variant>> = con.async_raw_query("SELECT Name FROM Win32_OperatingSystem").await?;
     /// #   Ok(())
@@ -87,13 +88,13 @@ impl WMIConnection {
     /// # use wmi::*;
     /// # use std::collections::HashMap;
     /// # use futures::executor::block_on;
-    /// # fn main() -> Result<(), wmi::WMIError> {
+    /// # fn main() -> wmi::WMIResult<()> {
     /// #   block_on(exec_async_query())?;
     /// #   Ok(())
     /// # }
     /// #
     /// # async fn exec_async_query() -> WMIResult<()> {
-    /// # let con = WMIConnection::new(COMLibrary::new()?.into())?;
+    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
     /// use serde::Deserialize;
     /// #[derive(Deserialize, Debug)]
     /// struct Win32_Process {
@@ -122,7 +123,7 @@ impl WMIConnection {
     where
         T: de::DeserializeOwned,
     {
-        let query_text = build_query::<T>(Some(&filters))?;
+        let query_text = build_query::<T>(Some(filters))?;
 
         self.async_raw_query(&query_text).await
     }
@@ -132,11 +133,10 @@ impl WMIConnection {
 #[allow(non_camel_case_types)]
 #[cfg(test)]
 mod tests {
-    use crate::tests::fixtures::*;
-    use crate::Variant;
+    use crate::{tests::fixtures::*, Variant};
     use futures::stream::{self, StreamExt};
-    use serde::Deserialize;
     use std::collections::HashMap;
+    use serde::Deserialize;
 
     #[async_std::test]
     async fn async_it_works_async() {

--- a/src/benches/benchmark.rs
+++ b/src/benches/benchmark.rs
@@ -1,10 +1,9 @@
 #![allow(non_snake_case)]
 
-use criterion::{criterion_group, Criterion};
+use wmi::{COMLibrary, Variant, WMIConnection};
+use criterion::{Criterion, criterion_group};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-use wmi::{COMLibrary, Variant, WMIConnection};
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename = "Win32_Account")]

--- a/src/bin/wmiq.rs
+++ b/src/bin/wmiq.rs
@@ -1,9 +1,8 @@
-use std::collections::HashMap;
-use std::env::args;
 use wmi::{COMLibrary, Variant, WMIConnection};
+use std::{collections::HashMap, env::args};
 
 fn main() {
-    let wmi_con = WMIConnection::new(COMLibrary::new().unwrap().into()).unwrap();
+    let wmi_con = WMIConnection::new(COMLibrary::new().unwrap()).unwrap();
     let args: Vec<String> = args().collect();
     let query = match args.get(1) {
         None => {

--- a/src/bstr.rs
+++ b/src/bstr.rs
@@ -1,14 +1,15 @@
-use crate::WMIError;
-use std::convert::TryFrom;
-use std::ops::Drop;
-use std::ptr::{null, NonNull};
+use crate::{WMIError, WMIResult};
+use std::{ptr::{NonNull, null}, convert::TryFrom, ops::Drop};
 use winapi::{
-    shared::ntdef::LPCWSTR, shared::wtypes::BSTR, shared::wtypesbase::OLECHAR, um::oleauto::*,
+    shared::ntdef::LPCWSTR,
+    shared::wtypes::BSTR,
+    shared::wtypesbase::OLECHAR,
+    um::oleauto::*,
 };
 
 /// A non-null [BSTR]
 ///
-/// [BSTR]:         https://docs.microsoft.com/en-us/previous-versions/windows/desktop/automat/bstr
+/// [BSTR]: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/automat/bstr
 pub(crate) struct BStr(NonNull<OLECHAR>);
 
 impl Drop for BStr {
@@ -18,7 +19,7 @@ impl Drop for BStr {
 }
 
 impl BStr {
-    pub fn from_str(s: &str) -> Result<Self, WMIError> {
+    pub fn from_str(s: &str) -> WMIResult<Self> {
         let len = s.encode_utf16().count();
         let len32 = u32::try_from(len).map_err(|_| WMIError::ConvertLengthError(len as _))?;
 

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1,8 +1,7 @@
-use super::WMIError;
+use crate::WMIError;
+use std::{str::FromStr, fmt};
 use chrono::prelude::*;
 use serde::{de, ser};
-use std::fmt;
-use std::str::FromStr;
 
 /// A wrapper type around `chrono`'s `DateTime` (if the `chrono` feature is active. ), which supports parsing from WMI-format strings.
 #[derive(Debug)]

--- a/src/datetime_time.rs
+++ b/src/datetime_time.rs
@@ -1,12 +1,13 @@
-use super::WMIError;
-use serde::{de, ser};
-use std::fmt;
-use std::str::FromStr;
-
+use crate::WMIError;
 use time::{
-    format_description::FormatItem, macros::format_description, parsing::Parsed, PrimitiveDateTime,
+    format_description::FormatItem,
+    parsing::Parsed,
+    macros::format_description,
+    PrimitiveDateTime,
     UtcOffset,
 };
+use std::{str::FromStr, fmt};
+use serde::{de, ser};
 
 /// A wrapper type around `time`'s `OffsetDateTime` (if the
 // `time` feature is active), which supports parsing from WMI-format strings.

--- a/src/de/meta.rs
+++ b/src/de/meta.rs
@@ -1,11 +1,10 @@
-use serde::de::{self, Deserialize, Deserializer, Visitor};
+use serde::de::{value::Error, self, Deserialize, Deserializer, Visitor};
 use serde::forward_to_deserialize_any;
 
 /// Return the fields of a struct.
 /// Taken directly from <https://github.com/serde-rs/serde/issues/1110>
 ///
-pub fn struct_name_and_fields<'de, T>(
-) -> Result<(&'static str, &'static [&'static str]), serde::de::value::Error>
+pub fn struct_name_and_fields<'de, T>() -> Result<(&'static str, &'static [&'static str]), Error>
 where
     T: Deserialize<'de>,
 {
@@ -15,7 +14,7 @@ where
     }
 
     impl<'de, 'a> Deserializer<'de> for StructNameAndFieldsDeserializer<'a> {
-        type Error = serde::de::value::Error;
+        type Error = Error;
 
         fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
         where
@@ -88,7 +87,7 @@ where
 /// > All following characters must be in set S2 where S2 = S1 union {U+0030...U+0039} \[This is alphabetic, underscore, plus Arabic numerals 0 through 9.\]<br>
 ///
 /// [DMTF-DSP0004]:     https://www.dmtf.org/sites/default/files/standards/documents/DSP0004V2.3_final.pdf
-fn validate_identifier<E: serde::de::Error>(s: &str) -> Result<&str, E> {
+fn validate_identifier<E: de::Error>(s: &str) -> Result<&str, E> {
     fn is_s1(ch: char) -> bool {
         match ch {
             '\u{005f}' => true,

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -1,8 +1,6 @@
-use super::WMIError;
+use crate::WMIError;
+use std::{str::FromStr, time::Duration, fmt};
 use serde::{de, ser};
-use std::fmt;
-use std::str::FromStr;
-use std::time::Duration;
 
 /// A wrapper type around Duration, which supports parsing from WMI-format strings.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,23 +88,23 @@
 //!
 //! # Subscribing to event notifications
 //!
-//! Using this crate you can subscribe to events notifications that are generated upon chnages in WMI data and services.
+//! Using this crate you can subscribe to events notifications generated upon changes in WMI data and services.
 //!
 //! When querying for events, it is important to remember there are two types of event notifications. \
-//! The first one are notifications about changes to the standard WMI data models. Thye are called **intrinsic events**. \
+//! The first one is notifications about changes to the standard WMI data models. They are called **intrinsic events**. \
 //! Events like [`__InstanceCreationEvent`] or [`__NamespaceDeletionEvent`] are examples of such events.
 //!
-//! The second type are notifications about chnages made by providers. Thye are called **extrinsic events**. \
+//! The second type is notifications about changes made by providers. They are called **extrinsic events**.  \
 //! Any WMI class deriving from the [`__ExtrinsicEvent`] class is an extrinsic event. \
 //! An example of such events are [`Win32_ProcessStartTrace`] and [`Win32_VolumeChangeEvent`] classes.
 //!
-//! For more informations about event queries, [see here](https://docs.microsoft.com/en-us/windows/win32/wmisdk/receiving-a-wmi-event#event-queries).\
+//! For more information about event queries, [see here](https://docs.microsoft.com/en-us/windows/win32/wmisdk/receiving-a-wmi-event#event-queries).\
 //! You can use [WMI Code Creator] to see available events and create queries for them.
 //!
-//! The [`notification`] method returns an interator that waits for any incoming events
+//! The [`notification`] method returns an iterator that waits for any incoming events
 //! resulting from the provided query. Loops reading from this iterator will not end until they are broken.
 //!
-//! An example of subscribing to an intrinsic event notification for every new [`Win32_Process`]:
+//! An example of subscribing to an intrinsic event notification for every new [`Win32_Process`]
 //! ```edition2018
 //! # fn main() -> wmi::WMIResult<()> {
 //! # use wmi::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,8 +106,11 @@
 //!
 //! An example of subscribing to an intrinsic event notification for every new [`Win32_Process`]
 //! ```edition2018
-//! # fn main() -> wmi::WMIResult<()> {
 //! # use wmi::*;
+//! # #[cfg(not(feature = "test"))]
+//! # fn main() {}
+//! # #[cfg(feature = "test")]
+//! # fn main() -> WMIResult<()>{
 //! # use serde::Deserialize;
 //! # use std::collections::HashMap;
 //! # let wmi_con = WMIConnection::new(COMLibrary::new()?)?;
@@ -133,7 +136,7 @@
 //! filters.insert("TargetInstance".to_owned(), FilterValue::IsA("Win32_Process"));
 //!
 //! let iterator = wmi_con.filtered_notification::<NewProcessEvent>(&filters)?;
-//! # wmi::start_program();
+//! # tests::start_test_program();
 //!
 //! for result in iterator {
 //!     let process = result?.target_instance;
@@ -269,25 +272,3 @@ pub use variant::Variant;
 #[doc = include_str!("../README.md")]
 #[cfg(all(doctest, feature = "chrono"))]
 pub struct ReadmeDoctests;
-
-// Functions for doc tests. `#[cfg(doctest)]` does not work.
-#[doc(hidden)]
-pub fn start_program() {
-    std::process::Command::new("C:\\Windows\\System32\\cmd.exe")
-        .args(["timeout", "1"])
-        .spawn()
-        .expect("failed to run test program");
-}
-
-#[doc(hidden)]
-pub fn ignore_access_denied(result: WMIResult<()>) -> WMIResult<()> {
-    use winapi::{shared::ntdef::HRESULT, um::wbemcli::WBEM_E_ACCESS_DENIED};
-    if let Err(e) = result {
-        if let WMIError::HResultError { hres } = e {
-            if hres != WBEM_E_ACCESS_DENIED as HRESULT {
-                return Err(e);
-            }
-        }
-    }
-    Ok(())
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@
 //!
 //! let mut filters = HashMap::<String, FilterValue>::new();
 //!
-//! filters.insert("TargetInstance".to_owned(), FilterValue::IsA::<Process>()?);
+//! filters.insert("TargetInstance".to_owned(), FilterValue::is_a::<Process>()?);
 //!
 //! let iterator = wmi_con.filtered_notification::<NewProcessEvent>(&filters, Some(Duration::from_secs(1)))?;
 //! # tests::start_test_program();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@
 //! # #[cfg(feature = "test")]
 //! # fn main() -> WMIResult<()>{
 //! # use serde::Deserialize;
-//! # use std::collections::HashMap;
+//! # use std::{collections::HashMap, time::Duration};
 //! # let wmi_con = WMIConnection::new(COMLibrary::new()?)?;
 //! #[derive(Deserialize, Debug)]
 //! #[serde(rename = "__InstanceCreationEvent")]
@@ -132,8 +132,8 @@
 //!
 //! let mut filters = HashMap::<String, FilterValue>::new();
 //!
-//! filters.insert("".to_owned(), FilterValue::Within(1));
-//! filters.insert("TargetInstance".to_owned(), FilterValue::IsA("Win32_Process"));
+//! filters.insert("".to_owned(), FilterValue::Within(Duration::from_secs(1)));
+//! filters.insert("TargetInstance".to_owned(), FilterValue::IsA::<Process>()?);
 //!
 //! let iterator = wmi_con.filtered_notification::<NewProcessEvent>(&filters)?;
 //! # tests::start_test_program();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,10 @@
 //! Before using WMI, a connection must be created.
 //!
 //! ```rust
-//! # fn main() -> Result<(), wmi::WMIError> {
+//! # fn main() -> wmi::WMIResult<()> {
 //! use wmi::{COMLibrary, WMIConnection};
 //! let com_con = COMLibrary::new()?;
-//! let wmi_con = WMIConnection::new(com_con.into())?;
+//! let wmi_con = WMIConnection::new(com_con)?;
 //! #   Ok(())
 //! # }
 //! ```
@@ -32,9 +32,9 @@
 //! Using this enum, we can execute a simple WMI query and inspect the results.
 //!
 //! ```edition2018
-//! # fn main() -> Result<(), wmi::WMIError> {
+//! # fn main() -> wmi::WMIResult<()> {
 //! use wmi::*;
-//! let wmi_con = WMIConnection::new(COMLibrary::new()?.into())?;
+//! let wmi_con = WMIConnection::new(COMLibrary::new()?)?;
 //! use std::collections::HashMap;
 //! use wmi::Variant;
 //! let results: Vec<HashMap<String, Variant>> = wmi_con.raw_query("SELECT * FROM Win32_OperatingSystem").unwrap();
@@ -51,9 +51,9 @@
 //! Using `serde`, it is possible to return a struct representing the the data.
 //!
 //! ```edition2018
-//! # fn main() -> Result<(), wmi::WMIError> {
+//! # fn main() -> wmi::WMIResult<()> {
 //! # use wmi::*;
-//! # let wmi_con = WMIConnection::new(COMLibrary::new()?.into())?;
+//! # let wmi_con = WMIConnection::new(COMLibrary::new()?)?;
 //! use serde::Deserialize;
 //! # #[cfg(feature = "chrono")]
 //! use wmi::WMIDateTime;
@@ -86,6 +86,75 @@
 //! [`VARIANT`]: https://docs.microsoft.com/en-us/windows/desktop/api/oaidl/ns-oaidl-tagvariant
 //! [WMI class]: https://docs.microsoft.com/en-us/windows/desktop/cimwin32prov/win32-operatingsystem
 //!
+//! # Subscribing to event notifications
+//!
+//! Using this crate you can subscribe to events notifications that are generated upon chnages in WMI data and services.
+//!
+//! When querying for events, it is important to remember there are two types of event notifications. \
+//! The first one are notifications about changes to the standard WMI data models. Thye are called **intrinsic events**. \
+//! Events like [`__InstanceCreationEvent`] or [`__NamespaceDeletionEvent`] are examples of such events.
+//!
+//! The second type are notifications about chnages made by providers. Thye are called **extrinsic events**. \
+//! Any WMI class deriving from the [`__ExtrinsicEvent`] class is an extrinsic event. \
+//! An example of such events are [`Win32_ProcessStartTrace`] and [`Win32_VolumeChangeEvent`] classes.
+//!
+//! For more informations about event queries, [see here](https://docs.microsoft.com/en-us/windows/win32/wmisdk/receiving-a-wmi-event#event-queries).\
+//! You can use [WMI Code Creator] to see available events and create queries for them.
+//!
+//! The [`notification`] method returns an interator that waits for any incoming events
+//! resulting from the provided query. Loops reading from this iterator will not end until they are broken.
+//!
+//! An example of subscribing to an intrinsic event notification for every new [`Win32_Process`]:
+//! ```edition2018
+//! # fn main() -> wmi::WMIResult<()> {
+//! # use wmi::*;
+//! # use serde::Deserialize;
+//! # use std::collections::HashMap;
+//! # let wmi_con = WMIConnection::new(COMLibrary::new()?)?;
+//! #[derive(Deserialize, Debug)]
+//! #[serde(rename = "__InstanceCreationEvent")]
+//! #[serde(rename_all = "PascalCase")]
+//! struct NewProcessEvent {
+//!     target_instance: Process
+//! }
+//!
+//! #[derive(Deserialize, Debug)]
+//! #[serde(rename = "Win32_Process")] // Renaming this struct in unnecessary
+//! #[serde(rename_all = "PascalCase")]
+//! struct Process {
+//!     process_id: u32,
+//!     name: String,
+//!     executable_path: Option<String>,
+//! }
+//!
+//! let mut filters = HashMap::<String, FilterValue>::new();
+//!
+//! filters.insert("".to_owned(), FilterValue::Within(1));
+//! filters.insert("TargetInstance".to_owned(), FilterValue::IsA("Win32_Process"));
+//!
+//! let iterator = wmi_con.filtered_notification::<NewProcessEvent>(&filters)?;
+//!
+//! for result in iterator {
+//!     let process = result?.target_instance;
+//!     println!("New process!");
+//!     println!("PID:        {}", process.process_id);
+//!     println!("Name:       {}", process.name);
+//!     println!("Executable: {:?}", process.executable_path);
+//! #     break;
+//! } // Loop will end only on error
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [`Win32_Process`]: https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-process
+//! [`__InstanceCreationEvent`]: https://docs.microsoft.com/en-us/windows/win32/wmisdk/--instancecreationevent
+//! [`__NamespaceDeletionEvent`]: https://docs.microsoft.com/en-us/windows/win32/wmisdk/--namespacedeletionevent
+//! [`__ExtrinsicEvent`]: https://docs.microsoft.com/en-us/windows/win32/wmisdk/--extrinsicevent
+//! [`Win32_ProcessStartTrace`]: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/krnlprov/win32-processstarttrace
+//! [`Win32_VolumeChangeEvent`]: https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-volumechangeevent
+//! [WMI Code Creator]: https://www.microsoft.com/en-us/download/details.aspx?id=8572
+//! [`notification`]: connection/struct.WMIConnection.html#method.notification
+//!
 //! # Internals
 //!
 //! [`WMIConnection`](WMIConnection) is used to create and execute a WMI query, returning
@@ -112,10 +181,10 @@
 //! ```edition2018
 //! # use futures::executor::block_on;
 //! # block_on(exec_async_query()).unwrap();
-//! # async fn exec_async_query() -> Result<(), wmi::WMIError> {
+//! # async fn exec_async_query() -> wmi::WMIResult<()> {
 //! use wmi::*;
 //! use futures::StreamExt;
-//! let wmi_con = WMIConnection::new(COMLibrary::new()?.into())?;
+//! let wmi_con = WMIConnection::new(COMLibrary::new()?)?;
 //! let results = wmi_con
 //!     .exec_query_async_native_wrapper("SELECT OSArchitecture FROM Win32_OperatingSystem")?
 //!     .collect::<Vec<_>>().await;
@@ -127,9 +196,9 @@
 //! ```edition2018
 //! # use futures::executor::block_on;
 //! # block_on(exec_async_query()).unwrap();
-//! # async fn exec_async_query() -> Result<(), wmi::WMIError> {
+//! # async fn exec_async_query() -> wmi::WMIResult<()> {
 //! use wmi::*;
-//! let wmi_con = WMIConnection::new(COMLibrary::new()?.into())?;
+//! let wmi_con = WMIConnection::new(COMLibrary::new()?)?;
 //! use serde::Deserialize;
 //!
 //! #[derive(Deserialize, Debug)]
@@ -177,6 +246,8 @@ pub mod async_query;
 // Keep QuerySink implementation private
 pub(crate) mod query_sink;
 
+pub mod notification;
+
 #[cfg(any(test, feature = "test"))]
 pub mod tests;
 
@@ -190,7 +261,7 @@ pub use datetime::WMIDateTime;
 pub use datetime_time::WMIOffsetDateTime;
 
 pub use duration::WMIDuration;
-pub use query::{build_query, FilterValue};
+pub use query::{FilterValue, build_query};
 pub use utils::{WMIError, WMIResult};
 pub use variant::Variant;
 

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -130,7 +130,7 @@ impl WMIConnection {
     ///
     /// let mut filters = HashMap::new();
     ///
-    /// filters.insert("TargetInstance".to_owned(), FilterValue::IsA::<Win32_Process>()?);
+    /// filters.insert("TargetInstance".to_owned(), FilterValue::is_a::<Win32_Process>()?);
     ///
     /// let iterator = con.filtered_notification::<__InstanceCreationEvent>(&filters, Some(Duration::from_secs(1)))?;
 
@@ -279,7 +279,7 @@ impl WMIConnection {
     ///
     /// let mut filters = HashMap::new();
     ///
-    /// filters.insert("TargetInstance".to_owned(), FilterValue::IsA::<Win32_Process>()?);
+    /// filters.insert("TargetInstance".to_owned(), FilterValue::is_a::<Win32_Process>()?);
     ///
     /// let mut stream = con.async_filtered_notification::<__InstanceCreationEvent>(&filters, Some(Duration::from_secs(1)))?;
     ///
@@ -309,7 +309,7 @@ mod tests {
 
     pub fn notification_filters() -> HashMap<String, FilterValue> {
         let mut map = HashMap::<String, FilterValue>::new();
-        map.insert("TargetInstance".to_owned(), FilterValue::IsA::<LocalTime>().unwrap());
+        map.insert("TargetInstance".to_owned(), FilterValue::is_a::<LocalTime>().unwrap());
         map
     }
 

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -50,6 +50,9 @@ impl WMIConnection {
     ///
     /// ```edition2018
     /// # fn main() -> wmi::WMIResult<()> {
+    /// #   wmi::ignore_access_denied(run())
+    /// # }
+    /// # fn run() -> wmi::WMIResult<()> {
     /// # use wmi::*;
     /// # use std::collections::HashMap;
     /// # let con = WMIConnection::new(COMLibrary::new()?)?;
@@ -74,6 +77,9 @@ impl WMIConnection {
     ///
     /// ```edition2018
     /// # fn main() -> wmi::WMIResult<()> {
+    /// #   wmi::ignore_access_denied(run())
+    /// # }
+    /// # fn run() -> wmi::WMIResult<()> {
     /// use wmi::*;
     /// use serde::Deserialize;
     ///
@@ -175,8 +181,7 @@ impl WMIConnection {
     /// # use std::collections::HashMap;
     /// # use futures::{executor::block_on, StreamExt};
     /// # fn main() -> wmi::WMIResult<()> {
-    /// #   block_on(exec_async_query())?;
-    /// #   Ok(())
+    /// #   wmi::ignore_access_denied(block_on(exec_async_query()))
     /// # }
     /// #
     /// # async fn exec_async_query() -> WMIResult<()> {
@@ -205,8 +210,7 @@ impl WMIConnection {
     /// # use std::collections::HashMap;
     /// # use futures::executor::block_on;
     /// # fn main() -> wmi::WMIResult<()> {
-    /// #   block_on(exec_async_query())?;
-    /// #   Ok(())
+    /// #   wmi::ignore_access_denied(block_on(exec_async_query()))
     /// # }
     /// #
     /// # async fn exec_async_query() -> WMIResult<()> {
@@ -240,10 +244,14 @@ impl WMIConnection {
     ///
     /// ```edition2018
     /// # use wmi::*;
-    /// # use futures::executor::block_on;
+    /// # use futures::{future::FutureExt, select};
     /// # fn main() -> wmi::WMIResult<()> {
-    /// #   block_on(exec_async_query())?;
-    /// #   Ok(())
+    /// #   async_std::task::block_on(async {
+    /// #       select! { // End in 3 seconds or on event.
+    /// #           () = async_std::task::sleep(std::time::Duration::from_secs(3)).fuse() => Ok(()),
+    /// #           r = exec_async_query().fuse() => r
+    /// #       }
+    /// #   })
     /// # }
     /// #
     /// # async fn exec_async_query() -> WMIResult<()> {

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -301,9 +301,11 @@ mod tests {
     use crate::{tests::fixtures::*, FilterValue, WMIError};
     use winapi::{shared::ntdef::HRESULT, um::wbemcli::WBEM_E_UNPARSABLE_QUERY};
     use std::{collections::HashMap, time::Duration};
-    use chrono::Datelike;
     use serde::Deserialize;
     use futures::StreamExt;
+
+    #[cfg(feature = "chrono")]
+    use chrono::Datelike;
 
     const TEST_QUERY: &str = "SELECT * FROM __InstanceModificationEvent WHERE TargetInstance ISA 'Win32_LocalTime'";
 

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,0 +1,473 @@
+use crate::{
+    query_sink::{AsyncQueryResultStream, QuerySink, IWbemObjectSink},
+    result_enumerator::{QueryResultEnumerator, IWbemClassWrapper},
+    bstr::BStr,
+    utils::check_hres,
+    WMIConnection,
+    WMIResult,
+    FilterValue,
+    build_query,
+};
+use winapi::{
+    um::wbemcli::{IEnumWbemClassObject, WBEM_FLAG_FORWARD_ONLY, WBEM_FLAG_RETURN_IMMEDIATELY},
+    shared::ntdef::NULL,
+};
+use com::{production::ClassAllocation, AbiTransferable};
+use std::{collections::HashMap, ptr};
+use futures::{Stream, StreamExt};
+
+///
+/// ### Additional notification query methods
+///
+impl WMIConnection {
+    /// Execute the given query to receive events and return an iterator of WMI pointers.
+    /// It's better to use the other query methods, since this is relatively low level.
+    ///
+    pub fn notification_native_wrapper(&self, query: impl AsRef<str>) -> WMIResult<QueryResultEnumerator> {
+        let query_language = BStr::from_str("WQL")?;
+        let query = BStr::from_str(query.as_ref())?;
+
+        let mut p_enumerator = NULL as *mut IEnumWbemClassObject;
+
+        unsafe {
+            check_hres((*self.svc()).ExecNotificationQuery(
+                query_language.as_bstr(),
+                query.as_bstr(),
+                (WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY) as i32,
+                ptr::null_mut(),
+                &mut p_enumerator,
+            ))?;
+        }
+        log::trace!("Got enumerator {:?}", p_enumerator);
+
+        Ok(unsafe { QueryResultEnumerator::new(self, p_enumerator) })
+    }
+
+    /// Execute a free-text query and deserialize the incoming events.
+    /// Returns an iterator of WMIResult\<T\>.
+    /// Can be used either with a struct (like `query` and `filtered_query`),
+    /// but also with a generic map.
+    ///
+    /// ```edition2018
+    /// # fn main() -> wmi::WMIResult<()> {
+    /// # use wmi::*;
+    /// # use std::collections::HashMap;
+    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// let iterator = con.raw_notification::<HashMap<String, Variant>>("SELECT ProcessID, ProcessName FROM Win32_ProcessStartTrace")?;
+    /// #   Ok(()) // This query will fail when not run as admin
+    /// # }
+    /// ```
+    pub fn raw_notification<'a, T>(&'a self, query: impl AsRef<str>) -> WMIResult<impl Iterator<Item = WMIResult<T>> + 'a>
+    where
+        T: serde::de::DeserializeOwned + 'a,
+    {
+        let enumerator = self.notification_native_wrapper(query)?;
+        let iter = enumerator
+            .map(|item| match item {
+                Ok(wbem_class_obj) => wbem_class_obj.into_desr(),
+                Err(e) => Err(e),
+            });
+        Ok(iter)
+    }
+
+    /// Subscribe to the T event and return an iterator of WMIResult\<T\>.
+    ///
+    /// ```edition2018
+    /// # fn main() -> wmi::WMIResult<()> {
+    /// use wmi::*;
+    /// use serde::Deserialize;
+    ///
+    /// let con = WMIConnection::new(COMLibrary::new()?)?;
+    ///
+    /// #[derive(Deserialize, Debug)]
+    /// struct Win32_ProcessStartTrace {
+    ///     ProcessID: u32,
+    ///     ProcessName: String,
+    /// }
+    ///
+    /// let iterator = con.notification::<Win32_ProcessStartTrace>()?;
+    /// #   Ok(()) // This query will fail when not run as admin
+    /// # }
+    /// ```
+    pub fn notification<'a, T>(&'a self) -> WMIResult<impl Iterator<Item = WMIResult<T>> + 'a>
+    where
+        T: serde::de::DeserializeOwned + 'a,
+    {
+        let mut query_text = build_query::<T>(None)?;
+        fetch_everything(&mut query_text);
+        self.raw_notification(query_text)
+    }
+
+    /// Subscribe to the T event, while filtering according to `filters`.
+    /// Returns an iterator of WMIResult\<T\>.
+    ///
+    /// ```edition2018
+    /// # fn main() -> wmi::WMIResult<()> {
+    /// # use std::collections::HashMap;
+    /// # use wmi::*;
+    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// use serde::Deserialize;
+    /// #[derive(Deserialize, Debug)]
+    /// struct __InstanceCreationEvent {
+    ///     TargetInstance: Win32_Process,
+    /// }
+    ///
+    /// #[derive(Deserialize, Debug)]
+    /// struct Win32_Process {
+    ///     ProcessID: u32,
+    /// }
+    ///
+    /// let mut filters = HashMap::new();
+    ///
+    /// filters.insert("".to_owned(), FilterValue::Within(1));
+    /// filters.insert("TargetInstance".to_owned(), FilterValue::IsA("Win32_Process"));
+    ///
+    /// let iterator = con.filtered_notification::<__InstanceCreationEvent>(&filters)?;
+
+    /// #   Ok(())
+    /// # }
+    /// ```
+    pub fn filtered_notification<'a, T>(&'a self, filters: &HashMap<String, FilterValue>) -> WMIResult<impl Iterator<Item = WMIResult<T>> + 'a>
+    where
+        T: serde::de::DeserializeOwned + 'a,
+    {
+        let mut query_text = build_query::<T>(Some(filters))?;
+        fetch_everything(&mut query_text);
+        self.raw_notification(query_text)
+    }
+
+    /// Wrapper for the [ExecNotificationQueryAsync](https://docs.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemservices-execnotificationqueryasync)
+    /// method. Provides safety checks, and returns results
+    /// as a stream instead of the original Sink.
+    ///
+    pub fn async_notification_native_wrapper(&self, query: impl AsRef<str>) -> WMIResult<impl Stream<Item = WMIResult<IWbemClassWrapper>>> {
+        let query_language = BStr::from_str("WQL")?;
+        let query = BStr::from_str(query.as_ref())?;
+
+        let stream = AsyncQueryResultStream::new();
+        // The internal RefCount has initial value = 1.
+        let p_sink: ClassAllocation<QuerySink> = QuerySink::allocate(stream.clone());
+        let p_sink_handle = IWbemObjectSink::from(&**p_sink);
+
+        unsafe {
+            // As p_sink's RefCount = 1 before this call,
+            // p_sink won't be dropped at the end of ExecNotificationQueryAsync
+            check_hres((*self.svc()).ExecNotificationQueryAsync(
+                query_language.as_bstr(),
+                query.as_bstr(),
+                0,
+                ptr::null_mut(),
+                p_sink_handle.get_abi().as_ptr() as *mut _,
+            ))?;
+        }
+
+        Ok(stream)
+    }
+
+    /// Async version of [`raw_notification`](WMIConnection#method.raw_notification)
+    /// Execute a free-text query and deserialize the incoming events.
+    /// Returns a stream of WMIResult\<T\>.
+    /// Can be used either with a struct (like `query` and `filtered_query`),
+    /// but also with a generic map.
+    ///
+    /// ```edition2018
+    /// # use wmi::*;
+    /// # use std::collections::HashMap;
+    /// # use futures::{executor::block_on, StreamExt};
+    /// # fn main() -> wmi::WMIResult<()> {
+    /// #   block_on(exec_async_query())?;
+    /// #   Ok(())
+    /// # }
+    /// #
+    /// # async fn exec_async_query() -> WMIResult<()> {
+    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// let mut stream = con.async_raw_notification::<HashMap<String, Variant>>("SELECT ProcessID, ProcessName FROM Win32_ProcessStartTrace")?;
+    /// # let event = stream.next().await.unwrap()?;
+    /// #   Ok(()) // This query will fail when not run as admin
+    /// # }
+    /// ```
+    pub fn async_raw_notification<T>(&self, query: impl AsRef<str>) -> WMIResult<impl Stream<Item = WMIResult<T>>>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let stream = self.async_notification_native_wrapper(query)?
+            .map(|item| match item {
+                Ok(wbem_class_obj) => wbem_class_obj.into_desr(),
+                Err(e) => Err(e),
+            });
+        Ok(stream)
+    }
+
+    /// Subscribe to the T event and return a stream of WMIResult\<T\>.
+    ///
+    /// ```edition2018
+    /// # use wmi::*;
+    /// # use std::collections::HashMap;
+    /// # use futures::executor::block_on;
+    /// # fn main() -> wmi::WMIResult<()> {
+    /// #   block_on(exec_async_query())?;
+    /// #   Ok(())
+    /// # }
+    /// #
+    /// # async fn exec_async_query() -> WMIResult<()> {
+    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// use futures::StreamExt;
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Deserialize, Debug)]
+    /// struct Win32_ProcessStartTrace {
+    ///     ProcessID: u32,
+    ///     ProcessName: String,
+    /// }
+    ///
+    /// let mut stream = con.async_notification::<Win32_ProcessStartTrace>()?;
+    ///
+    /// let event = stream.next().await.unwrap()?;
+    /// #   Ok(()) // This query will fail when not run as admin
+    /// # }
+    /// ```
+    pub fn async_notification<T>(&self) -> WMIResult<impl Stream<Item = WMIResult<T>>>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let mut query_text = build_query::<T>(None)?;
+        fetch_everything(&mut query_text);
+        self.async_raw_notification(query_text)
+    }
+
+    /// Subscribe to the T event, while filtering according to `filters`.
+    /// Returns a stream of WMIResult\<T\>.
+    ///
+    /// ```edition2018
+    /// # use wmi::*;
+    /// # use futures::executor::block_on;
+    /// # fn main() -> wmi::WMIResult<()> {
+    /// #   block_on(exec_async_query())?;
+    /// #   Ok(())
+    /// # }
+    /// #
+    /// # async fn exec_async_query() -> WMIResult<()> {
+    /// # use std::collections::HashMap;
+    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// use futures::StreamExt;
+    /// use serde::Deserialize;
+    /// #[derive(Deserialize, Debug)]
+    /// struct __InstanceCreationEvent {
+    ///     TargetInstance: Win32_Process,
+    /// }
+    ///
+    /// #[derive(Deserialize, Debug)]
+    /// struct Win32_Process {
+    ///     ProcessID: u32,
+    /// }
+    ///
+    /// let mut filters = HashMap::new();
+    ///
+    /// filters.insert("".to_owned(), FilterValue::Within(1));
+    /// filters.insert("TargetInstance".to_owned(), FilterValue::IsA("Win32_Process"));
+    ///
+    /// let mut stream = con.async_filtered_notification::<__InstanceCreationEvent>(&filters)?;
+    ///
+    /// let event = stream.next().await.unwrap()?;
+    /// #   Ok(())
+    /// # }
+    /// ```
+    pub fn async_filtered_notification<T>(&self, filters: &HashMap<String, FilterValue>) -> WMIResult<impl Stream<Item = WMIResult<T>>>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let mut query_text = build_query::<T>(Some(filters))?;
+        fetch_everything(&mut query_text);
+        self.async_raw_notification(query_text)
+    }
+}
+
+// This is a workaround to the following issue.
+// When querying for notifications, often times a query will contain object properties.
+// Since `wmi::de::meta:struct_name_and_fields` isn't able to get fields names from that inner object
+// we need to select the entire object in order to properly deserialize it.
+fn fetch_everything(query: &mut String) {
+    if let Some(index) = query.find(" FROM ") {
+        *query = format!("SELECT *{}", &query[index..]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{tests::fixtures::*, FilterValue, WMIError};
+    use winapi::{shared::ntdef::HRESULT, um::wbemcli::WBEM_E_UNPARSABLE_QUERY};
+    use std::collections::HashMap;
+    use chrono::Datelike;
+    use serde::Deserialize;
+    use futures::StreamExt;
+
+    const TEST_QUERY: &str = "SELECT * FROM __InstanceModificationEvent WHERE TargetInstance ISA 'Win32_LocalTime'";
+
+    pub fn notification_filters() -> HashMap<String, FilterValue> {
+        let mut map = HashMap::<String, FilterValue>::new();
+        map.insert("".to_owned(), FilterValue::Within(1));
+        map.insert("TargetInstance".to_owned(), FilterValue::IsA("Win32_LocalTime"));
+        map
+    }
+
+    #[derive(Deserialize, Debug)]
+    #[serde(rename = "__InstanceModificationEvent")]
+    #[serde(rename_all = "PascalCase")]
+    pub struct InstanceModification {
+        target_instance: LocalTime,
+    }
+
+    #[derive(Deserialize, Debug)]
+    #[serde(rename = "Win32_LocalTime")]
+    #[serde(rename_all = "PascalCase")]
+    pub struct LocalTime {
+        year: u32,
+    }
+
+    #[test]
+    fn it_works() {
+        let wmi_con = wmi_con();
+
+        let enumerator = wmi_con.notification_native_wrapper(TEST_QUERY).unwrap();
+
+        for res in enumerator {
+            let w = res.unwrap();
+            let mut props = w.list_properties().unwrap();
+
+            props.sort();
+
+            assert_eq!(props.len(), 4);
+            assert_eq!(props[..2], ["PreviousInstance", "SECURITY_DESCRIPTOR"]);
+            assert_eq!(props[props.len() - 2..], ["TIME_CREATED", "TargetInstance"]);
+
+            break; // Will wait forever otherwise
+        }
+    }
+
+    #[test]
+    fn it_fails_gracefully() {
+        let wmi_con = wmi_con();
+
+        let enumerator = wmi_con.notification_native_wrapper("SELECT NoSuchField FROM __InstanceModificationEvent WHERE TargetInstance ISA 'Win32_LocalTime'").unwrap();
+
+        for res in enumerator {
+            assert!(res.is_ok());
+            let props = res.unwrap().list_properties().unwrap();
+
+            assert_eq!(props.len(), 0);
+
+            break; // Will wait forever otherwise
+        }
+    }
+
+    #[test]
+    fn it_fails_gracefully_with_invalid_sql() {
+        let wmi_con = wmi_con();
+
+        let result = wmi_con.notification_native_wrapper("42");
+
+        match result {
+            Ok(_) => assert!(false),
+            Err(wmi_err) => match wmi_err {
+                WMIError::HResultError { hres } => assert_eq!(hres, WBEM_E_UNPARSABLE_QUERY as HRESULT),
+                _ => assert!(false),
+            },
+        }
+    }
+
+    #[test]
+    fn it_can_run_raw_notification() {
+        let wmi_con = wmi_con();
+
+        let iterator = wmi_con.raw_notification::<InstanceModification>(TEST_QUERY).unwrap();
+
+        for local_time in iterator {
+            assert!(local_time.is_ok());
+            let local_time = local_time.unwrap().target_instance;
+            assert_eq!(local_time.year as i32, chrono::Local::now().year());
+            break; // Will wait forever otherwise
+        }
+    }
+
+    #[test]
+    fn it_can_run_filtered_notification() {
+        let wmi_con = wmi_con();
+
+        let iterator = wmi_con.filtered_notification::<InstanceModification>(&notification_filters()).unwrap();
+
+        for local_time in iterator {
+            assert!(local_time.is_ok());
+            let local_time = local_time.unwrap().target_instance;
+            assert_eq!(local_time.year as i32, chrono::Local::now().year());
+            break; // Will wait forever otherwise
+        }
+    }
+
+    #[async_std::test]
+    async fn async_it_works_async_std() {
+        let wmi_con = wmi_con();
+
+        let result = wmi_con.async_notification_native_wrapper(TEST_QUERY)
+            .unwrap()
+            .next()
+            .await
+            .unwrap();
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn async_it_works_async_tokio() {
+        let wmi_con = wmi_con();
+
+        let result = wmi_con.async_notification_native_wrapper(TEST_QUERY)
+            .unwrap()
+            .next()
+            .await
+            .unwrap();
+
+        assert!(result.is_ok());
+    }
+
+    #[async_std::test]
+    async fn async_it_handles_invalid_query() {
+        let wmi_con = wmi_con();
+
+        let result = wmi_con.async_notification_native_wrapper("Invalid Query");
+
+        assert!(result.is_err());
+        if let WMIError::HResultError { hres } = result.err().unwrap() {
+            assert_eq!(hres, WBEM_E_UNPARSABLE_QUERY as HRESULT)
+        } else {
+            assert!(false, "Invalid WMIError type");
+        }
+    }
+
+    #[async_std::test]
+    async fn async_it_provides_raw_notification_result() {
+        let wmi_con = wmi_con();
+
+        let result = wmi_con.async_raw_notification::<InstanceModification>(TEST_QUERY)
+            .unwrap()
+            .next()
+            .await
+            .unwrap();
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().target_instance.year as i32, chrono::Local::now().year())
+    }
+
+    #[async_std::test]
+    async fn async_it_provides_filtered_notification_result() {
+        let wmi_con = wmi_con();
+
+        let result = wmi_con.async_filtered_notification::<InstanceModification>(&notification_filters())
+            .unwrap()
+            .next()
+            .await
+            .unwrap();
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().target_instance.year as i32, chrono::Local::now().year())
+    }
+}

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -49,11 +49,14 @@ impl WMIConnection {
     /// but also with a generic map.
     ///
     /// ```edition2018
+    /// # use wmi::*;
+    /// # #[cfg(not(feature = "test"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "test")]
     /// # fn main() -> wmi::WMIResult<()> {
-    /// #   wmi::ignore_access_denied(run())
+    /// #   tests::ignore_access_denied(run())
     /// # }
     /// # fn run() -> wmi::WMIResult<()> {
-    /// # use wmi::*;
     /// # use std::collections::HashMap;
     /// # let con = WMIConnection::new(COMLibrary::new()?)?;
     /// let iterator = con.raw_notification::<HashMap<String, Variant>>("SELECT ProcessID, ProcessName FROM Win32_ProcessStartTrace")?;
@@ -76,11 +79,14 @@ impl WMIConnection {
     /// Subscribe to the T event and return an iterator of WMIResult\<T\>.
     ///
     /// ```edition2018
+    /// use wmi::*;
+    /// # #[cfg(not(feature = "test"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "test")]
     /// # fn main() -> wmi::WMIResult<()> {
-    /// #   wmi::ignore_access_denied(run())
+    /// #   tests::ignore_access_denied(run())
     /// # }
     /// # fn run() -> wmi::WMIResult<()> {
-    /// use wmi::*;
     /// use serde::Deserialize;
     ///
     /// let con = WMIConnection::new(COMLibrary::new()?)?;
@@ -180,8 +186,11 @@ impl WMIConnection {
     /// # use wmi::*;
     /// # use std::collections::HashMap;
     /// # use futures::{executor::block_on, StreamExt};
+    /// # #[cfg(not(feature = "test"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "test")]
     /// # fn main() -> wmi::WMIResult<()> {
-    /// #   wmi::ignore_access_denied(block_on(exec_async_query()))
+    /// #   tests::ignore_access_denied(block_on(exec_async_query()))
     /// # }
     /// #
     /// # async fn exec_async_query() -> WMIResult<()> {
@@ -209,8 +218,11 @@ impl WMIConnection {
     /// # use wmi::*;
     /// # use std::collections::HashMap;
     /// # use futures::executor::block_on;
+    /// # #[cfg(not(feature = "test"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "test")]
     /// # fn main() -> wmi::WMIResult<()> {
-    /// #   wmi::ignore_access_denied(block_on(exec_async_query()))
+    /// #   tests::ignore_access_denied(block_on(exec_async_query()))
     /// # }
     /// #
     /// # async fn exec_async_query() -> WMIResult<()> {

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -373,6 +373,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "chrono")]
     fn it_can_run_raw_notification() {
         let wmi_con = wmi_con();
 
@@ -386,6 +387,21 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "time")]
+    fn it_can_run_raw_notification() {
+        let wmi_con = wmi_con();
+
+        let mut iterator = wmi_con.raw_notification::<InstanceModification>(TEST_QUERY).unwrap();
+
+        let local_time = iterator.next().unwrap();
+        assert!(local_time.is_ok());
+
+        let local_time = local_time.unwrap().target_instance;
+        assert_eq!(local_time.year as i32, time::OffsetDateTime::now_utc().year());
+    }
+
+    #[test]
+    #[cfg(feature = "chrono")]
     fn it_can_run_filtered_notification() {
         let wmi_con = wmi_con();
 
@@ -396,6 +412,20 @@ mod tests {
 
         let local_time = local_time.unwrap().target_instance;
         assert_eq!(local_time.year as i32, chrono::Local::now().year());
+    }
+
+    #[test]
+    #[cfg(feature = "time")]
+    fn it_can_run_filtered_notification() {
+        let wmi_con = wmi_con();
+
+        let mut iterator = wmi_con.filtered_notification::<InstanceModification>(&notification_filters(), Some(Duration::from_secs_f32(0.1))).unwrap();
+
+        let local_time = iterator.next().unwrap();
+        assert!(local_time.is_ok());
+
+        let local_time = local_time.unwrap().target_instance;
+        assert_eq!(local_time.year as i32, time::OffsetDateTime::now_utc().year());
     }
 
     #[async_std::test]
@@ -439,6 +469,7 @@ mod tests {
     }
 
     #[async_std::test]
+    #[cfg(feature = "chrono")]
     async fn async_it_provides_raw_notification_result() {
         let wmi_con = wmi_con();
 
@@ -453,6 +484,22 @@ mod tests {
     }
 
     #[async_std::test]
+    #[cfg(feature = "time")]
+    async fn async_it_provides_raw_notification_result() {
+        let wmi_con = wmi_con();
+
+        let result = wmi_con.async_raw_notification::<InstanceModification>(TEST_QUERY)
+            .unwrap()
+            .next()
+            .await
+            .unwrap();
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().target_instance.year as i32, time::OffsetDateTime::now_utc().year())
+    }
+
+    #[async_std::test]
+    #[cfg(feature = "chrono")]
     async fn async_it_provides_filtered_notification_result() {
         let wmi_con = wmi_con();
 
@@ -464,5 +511,20 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap().target_instance.year as i32, chrono::Local::now().year())
+    }
+
+    #[async_std::test]
+    #[cfg(feature = "time")]
+    async fn async_it_provides_filtered_notification_result() {
+        let wmi_con = wmi_con();
+
+        let result = wmi_con.async_filtered_notification::<InstanceModification>(&notification_filters(), Some(Duration::from_secs_f32(0.1)))
+            .unwrap()
+            .next()
+            .await
+            .unwrap();
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().target_instance.year as i32, time::OffsetDateTime::now_utc().year())
     }
 }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -388,7 +388,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "time")]
-    fn it_can_run_raw_notification() {
+    fn it_can_run_raw_notification_on_time_crate() {
         let wmi_con = wmi_con();
 
         let mut iterator = wmi_con.raw_notification::<InstanceModification>(TEST_QUERY).unwrap();
@@ -416,7 +416,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "time")]
-    fn it_can_run_filtered_notification() {
+    fn it_can_run_filtered_notification_on_time_crate() {
         let wmi_con = wmi_con();
 
         let mut iterator = wmi_con.filtered_notification::<InstanceModification>(&notification_filters(), Some(Duration::from_secs_f32(0.1))).unwrap();
@@ -485,7 +485,7 @@ mod tests {
 
     #[async_std::test]
     #[cfg(feature = "time")]
-    async fn async_it_provides_raw_notification_result() {
+    async fn async_it_provides_raw_notification_result_on_time_crate() {
         let wmi_con = wmi_con();
 
         let result = wmi_con.async_raw_notification::<InstanceModification>(TEST_QUERY)
@@ -515,7 +515,7 @@ mod tests {
 
     #[async_std::test]
     #[cfg(feature = "time")]
-    async fn async_it_provides_filtered_notification_result() {
+    async fn async_it_provides_filtered_notification_result_on_time_crate() {
         let wmi_con = wmi_con();
 
         let result = wmi_con.async_filtered_notification::<InstanceModification>(&notification_filters(), Some(Duration::from_secs_f32(0.1)))

--- a/src/query.rs
+++ b/src/query.rs
@@ -541,7 +541,12 @@ mod tests {
 
             assert_eq!(props.len(), 64);
             assert_eq!(props[..2], ["BootDevice", "BuildNumber"]);
-            assert_eq!(props[props.len() - 2..], ["Version", "WindowsDirectory"])
+            assert_eq!(props[props.len() - 2..], ["Version", "WindowsDirectory"]);
+
+            let result = serde_json::to_string_pretty(&w);
+
+            assert!(result.is_ok());
+            assert!(result.unwrap().len() > 2)
         }
     }
 

--- a/src/query_sink.rs
+++ b/src/query_sink.rs
@@ -1,18 +1,17 @@
-use crate::WMIError;
-use crate::{result_enumerator::IWbemClassWrapper, WMIResult};
-use futures::Stream;
-use log::trace;
-use std::collections::VecDeque;
-use std::task::{Poll, Waker};
+use crate::{result_enumerator::IWbemClassWrapper, WMIResult, WMIError};
 use std::{
-    ptr::NonNull,
+    task::{Poll, Waker},
     sync::{Arc, Mutex},
+    collections::VecDeque,
+    ptr::NonNull,
 };
 use winapi::{
     ctypes::c_long,
     shared::{ntdef::HRESULT, winerror::E_POINTER, wtypes::BSTR},
     um::wbemcli::{IWbemClassObject, WBEM_STATUS_COMPLETE, WBEM_S_NO_ERROR},
 };
+use futures::Stream;
+use log::trace;
 
 com::interfaces! {
     #[uuid("7C857801-7381-11CF-884D-00AA004B2E24")]
@@ -102,7 +101,7 @@ impl Stream for AsyncQueryResultStream {
         if !inner
             .waker
             .as_ref()
-            .map(|current_waker| waker.will_wake(&current_waker))
+            .map(|current_waker| waker.will_wake(current_waker))
             .unwrap_or(false)
         {
             inner.waker.replace(waker.clone());
@@ -162,7 +161,7 @@ com::class! {
             // For error codes, see https://docs.microsoft.com/en-us/windows/win32/learnwin32/error-handling-in-com
             self.stream
                 .extend((0..lObjectCount).map(|i| {
-                if let Some(p_el) = NonNull::new(*apObjArray.offset(i as isize)) {
+                if let Some(p_el) = NonNull::new(*apObjArray.add(i)) {
                     let wbemClassObject = unsafe {
                         IWbemClassWrapper::clone(p_el)
                     };

--- a/src/result_enumerator.rs
+++ b/src/result_enumerator.rs
@@ -1,30 +1,34 @@
-use crate::de::wbem_class_de::from_wbem_class_obj;
 use crate::{
-    connection::WMIConnection, safearray::safe_array_to_vec_of_strings, utils::check_hres, BStr,
-    Variant, WMIError,
+    connection::WMIConnection,
+    de::wbem_class_de::from_wbem_class_obj,
+    safearray::safe_array_to_vec_of_strings,
+    utils::check_hres,
+    WMIResult,
+    WMIError,
+    Variant,
+    BStr,
 };
-use log::trace;
-use serde::de;
-use std::convert::TryInto;
-use std::{mem, ptr, ptr::NonNull};
-use winapi::um::oaidl::VARIANT;
-use winapi::um::oleauto::VariantClear;
 use winapi::{
     shared::ntdef::NULL,
     um::{
-        oaidl::SAFEARRAY,
-        oleauto::SafeArrayDestroy,
-        wbemcli::{
-            IEnumWbemClassObject, IWbemClassObject, WBEM_FLAG_ALWAYS, WBEM_FLAG_NONSYSTEM_ONLY,
-            WBEM_INFINITE,
-        },
+        oaidl::{SAFEARRAY, VARIANT},
+        wbemcli::{IEnumWbemClassObject, IWbemClassObject, WBEM_FLAG_ALWAYS, WBEM_FLAG_NONSYSTEM_ONLY, WBEM_INFINITE},
+        oleauto::{SafeArrayDestroy, VariantClear},
     },
 };
+use std::{
+    ptr::NonNull,
+    convert::TryInto,
+    mem,
+    ptr,
+};
+use serde::{de, Serialize};
+use log::trace;
 
 /// A wrapper around a raw pointer to IWbemClassObject, which also takes care of releasing
 /// the object when dropped.
 ///
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct IWbemClassWrapper {
     pub inner: NonNull<IWbemClassObject>,
 }
@@ -38,6 +42,7 @@ impl IWbemClassWrapper {
     /// [AddRef](https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-addref)
     /// to increment Reference Count.
     ///
+    /// # Safety
     /// See [Managing the lifetime of an object](https://docs.microsoft.com/en-us/windows/win32/learnwin32/managing-the-lifetime-of-an-object)
     /// and [Rules for managing Ref count](https://docs.microsoft.com/en-us/windows/win32/com/rules-for-managing-reference-counts)
     ///
@@ -49,7 +54,7 @@ impl IWbemClassWrapper {
 
     /// Return the names of all the properties of the given object.
     ///
-    pub fn list_properties(&self) -> Result<Vec<String>, WMIError> {
+    pub fn list_properties(&self) -> WMIResult<Vec<String>> {
         // This will store the properties names from the GetNames call.
         let mut p_names = NULL as *mut SAFEARRAY;
 
@@ -71,7 +76,7 @@ impl IWbemClassWrapper {
         }
     }
 
-    pub fn get_property(&self, property_name: &str) -> Result<Variant, WMIError> {
+    pub fn get_property(&self, property_name: &str) -> WMIResult<Variant> {
         let name_prop = BStr::from_str(property_name)?;
 
         let mut vt_prop: VARIANT = unsafe { mem::zeroed() };
@@ -96,29 +101,52 @@ impl IWbemClassWrapper {
         }
     }
 
-    pub fn path(&self) -> Result<String, WMIError> {
+    pub fn path(&self) -> WMIResult<String> {
         self.get_property("__Path").and_then(Variant::try_into)
     }
 
-    pub fn class(&self) -> Result<String, WMIError> {
+    pub fn class(&self) -> WMIResult<String> {
         self.get_property("__Class").and_then(Variant::try_into)
     }
 
-    pub fn into_desr<T>(self) -> Result<T, WMIError>
+    pub fn into_desr<T>(self) -> WMIResult<T>
     where
         T: de::DeserializeOwned,
     {
-        from_wbem_class_obj(&self).map_err(WMIError::from)
+        from_wbem_class_obj(self).map_err(WMIError::from)
+    }
+}
+
+impl Clone for IWbemClassWrapper {
+    fn clone(&self) -> Self {
+        unsafe { Self::clone(self.inner) }
     }
 }
 
 impl Drop for IWbemClassWrapper {
     fn drop(&mut self) {
         let ptr = self.inner.as_ptr();
-
         unsafe {
             (*ptr).Release();
         }
+    }
+}
+
+impl Serialize for IWbemClassWrapper {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer
+    {
+        // use serde::ser::SerializeStruct;
+        // let name = self.class().unwrap();
+        // let properties = self.list_properties().unwrap();
+        // let mut s = serializer.serialize_struct(&name, properties.len())?;
+        // for property in properties.iter() {
+        //     let value = self.get_property(&property).unwrap();
+        //     s.serialize_field(property, &value)?;
+        // }
+        // s.end()
+        serializer.serialize_none() // TODO: Write?
     }
 }
 
@@ -147,7 +175,7 @@ impl<'a> Drop for QueryResultEnumerator<'a> {
 }
 
 impl<'a> Iterator for QueryResultEnumerator<'a> {
-    type Item = Result<IWbemClassWrapper, WMIError>;
+    type Item = WMIResult<IWbemClassWrapper>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut pcls_obj = NULL as *mut IWbemClassObject;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,8 +1,8 @@
-use crate::COMLibrary;
-use crate::WMIConnection;
+use crate::{COMLibrary, WMIConnection};
 
 pub mod fixtures {
     use super::*;
+
     // This way we only setup COM security once per thread during tests.
     thread_local! {
         static COM_LIB: COMLibrary = COMLibrary::without_security().unwrap();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{COMLibrary, WMIConnection};
+use crate::{COMLibrary, WMIConnection, WMIResult, WMIError};
 
 pub mod fixtures {
     use super::*;
@@ -15,4 +15,23 @@ pub mod fixtures {
 
         wmi_con
     }
+}
+
+pub fn start_test_program() {
+    std::process::Command::new("C:\\Windows\\System32\\cmd.exe")
+        .args(["timeout", "1"])
+        .spawn()
+        .expect("failed to run test program");
+}
+
+pub fn ignore_access_denied(result: WMIResult<()>) -> WMIResult<()> {
+    use winapi::{shared::ntdef::HRESULT, um::wbemcli::WBEM_E_ACCESS_DENIED};
+    if let Err(e) = result {
+        if let WMIError::HResultError { hres } = e {
+            if hres != WBEM_E_ACCESS_DENIED as HRESULT {
+                return Err(e);
+            }
+        }
+    }
+    Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,13 @@
-use serde::{de, ser};
-use std::fmt::{Debug, Display};
-use thiserror::Error;
 use winapi::shared::{ntdef::HRESULT, wtypes::VARTYPE};
+use std::fmt::{Debug, Display};
+use serde::{de, ser};
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum WMIError {
+    /// You can find a useful resource for decoding error codes [here](https://docs.microsoft.com/en-us/windows/win32/wmisdk/wmi-error-constants)
+    /// (or a github version [here](https://github.com/MicrosoftDocs/win32/blob/docs/desktop-src/WmiSdk/wmi-error-constants.md))
     #[error("HRESULT Call failed with: {hres:#X}")]
     HResultError { hres: HRESULT },
     #[error(transparent)]
@@ -48,6 +50,8 @@ pub enum WMIError {
     NullPointerResult,
     #[error("Unimplemeted array item in query")]
     UnimplementedArrayItem,
+    #[error("Invalid variant {0} during deserialization")]
+    InvalidDeserializationVariantError(String),
 }
 
 impl de::Error for WMIError {
@@ -64,11 +68,10 @@ impl ser::Error for WMIError {
     }
 }
 
-pub fn check_hres(hres: HRESULT) -> Result<(), WMIError> {
+pub fn check_hres(hres: HRESULT) -> WMIResult<()> {
     if hres < 0 {
         return Err(WMIError::HResultError { hres });
     }
-
     Ok(())
 }
 

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -322,7 +322,7 @@ impl IUnknownWrapper {
 }
 
 impl Serialize for IUnknownWrapper {
-    /// IUnknownWrapper serializaes to `()`, since it should have been converted into Variant::Object
+    /// IUnknownWrapper serializaes to `()`, since it should have been converted into [Variant::Object]
     ///
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
In this pull request, I'm adding support for WMI Event notifications and deserialization of the Unknown Variant.
This PR closes #46.

Significant changes were made to `notifiaction.rs`, `variant.rs`, `result_enumerator.rs`, `query.rs`, `variant_de.rs`, and `wbem_class_de.rs`.
Other files only received some minor changes.

## Major changes

I've added a new file called `notifiaction.rs`, which contains new `WMIConnection` methods used to subscribe to WMI Event notifications. They utilize the `ExecNoticicationQuery` (and for async the Async equivalent) method.

Since intrinsic events hold event data inside their properties, I've added appropriate `Variant` variants and their processing.
The new `Variant::Unknown(IUnknownWrapper)` is a temporary variant used to pass the `IUknown` to the CIM conversion stage. From there it is converted into the `Variant::Object(IWbemClassWrapper)` using the `IUknown::QueryInterface()` method.

Also, because of how intrinsic events are queried, I've added new `FilterValue` variants.
New variants add support for the `WITHIN` clause and the `ISA` operator.

I've attempted to add deserialization of the `Variant::Object` and somewhat succeeded.
But it resulted in a quite major change to the `wbem_class_de::Deserializer`.
Since I don't know how to handle lifetimes and borrows that well, I needed to remove its lifetimes and make it own the `IWbemClassWrapper` copy.
I don't think this should break or change anything major, besides the need to clone the `IWbemClassWrapper`, which now implements the `Clone` trait.

I also wanted to add serialization to `IWbemClassWrapper`, since `Variant` implements `Serialize`, ~but for the same reason as above, I failed~ and I've somewhat succeeded.

## Minor changes

Most minor changes are attributed to documentation or Clippy suggestions.
I've also unified returns to all use the `WMIResult` alias instead of `Result<_, WMIError>`.
Lastly, I also fixed the `wbem_class_de::tests::it_desr_into_map` test. It was failing for me since I don't have the `en-US` lang.

---

Comments, suggestions, and explanations would be very welcome.

~Also, please note that doc tests might not ever complete, or they will only complete after a while because they will wait for a new process to start.~
