### PR TITLE
Little changes for workflows and cargo.toml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,17 +7,20 @@ on:
 
 jobs:
   create-release:
-    name: create-release
+    name: Release crate
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
 
-      - uses: actions-rs/toolchain@v1
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: actions-rs/cargo@v1
+
+      - name: Publish crate
+        uses: actions-rs/cargo@v1
         with:
           command: publish
           args: --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,48 +4,62 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: test
+    name: Run tests
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
 
-      - uses: actions-rs/toolchain@v1
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
 
       # Cargo build - Only chrono (default features)
-      - uses: actions-rs/cargo@v1
+      - name: Build - Default
+        uses: actions-rs/cargo@v1
         with:
           command: build
-
-      # Cargo build - Only time
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --no-default-features --features=time
 
       # Cargo build - No features
-      - uses: actions-rs/cargo@v1
+      - name: Build - No features
+        uses: actions-rs/cargo@v1
         with:
           command: build
           args: --no-default-features
 
+      # Cargo build - Only time
+      - name: Build - Only time feature
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --no-default-features --features=time
+
       # Cargo build - All features
-      - uses: actions-rs/cargo@v1
+      - name: Build - All features
+        uses: actions-rs/cargo@v1
         with:
           command: build
           args: --all-features
 
-      # Test time crate
-      - uses: actions-rs/cargo@v1
+      # Test on default features
+      - name: Test - All targets
+        uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features=time
+          args: --all-targets
 
-      # Test chrono
-      - uses: actions-rs/cargo@v1
+      # Test time crate
+      - name: Test - Only tests with the Time crate
+        uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features=chrono
+          args: --tests --no-default-features --features=time
+
+      # Test documentation with the 'test' feature
+      - name: Test - Only Documentation
+        uses: action-rs/cargo@v1
+        with:
+          command: test
+          args: --doc --features=test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
 
       # Test documentation with the 'test' feature
       - name: Test - Only Documentation
-        uses: action-rs/cargo@v1
+        uses: actions-rs/cargo@v1
         with:
           command: test
           args: --doc --features=test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,30 +22,27 @@ default-target = "x86_64-pc-windows-msvc"
 default = ["chrono"]
 # Use { default-features = false, features = ["time"] } to use `time` instead of `chrono`.
 
-test = ["lazy_static"]
-# Deprecated. async support is always enabled.
-async-query = []
+# For use in documentation tests
+test = []
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = ["objbase", "wbemcli", "objidlbase", "oaidl", "oleauto", "errhandlingapi", "wtypes", "wtypesbase"] }
-log = "0.4"
-widestring = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-chrono = { version = "0.4", features = ["serde"], optional = true }
 time = { version = "0.3", features = ["formatting", "parsing", "macros", "serde"], optional = true }
-lazy_static = { version = "1.4.0", optional = true }
-thiserror = "^1"
-futures = { version = "0.3" }
+chrono = { version = "0.4", features = ["serde"], optional = true }
+serde = { version = "1.0", features = ["derive"] }
 com = { version = "0.6", features = ["production"] }
+futures = { version = "0.3" }
+widestring = "1.0"
+thiserror = "^1"
+log = "0.4"
 
 [dev-dependencies]
-lazy_static = "1.4.0"
-serde_json = { version = "1.0" }
-criterion = "0.4"
-tempdir = "0.3"
 async-std = { version = "1.10",  features = ["attributes"] }
 tokio = { version = "1.20.0", features = ["rt", "macros"] }
+serde_json = { version = "1.0" }
 sys-locale = "0.2.1"
+criterion = "0.4"
+tempdir = "0.3"
 
 [[bin]]
 name = "wmiq"

--- a/src/benches/benchmark.rs
+++ b/src/benches/benchmark.rs
@@ -51,9 +51,9 @@ pub struct Process {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename = "CIM_ProcessExecutable")]
 pub struct ProcessExecutable {
-    pub BaseAddress: String,
     pub Antecedent: String,
     pub Dependent: String,
+    pub BaseAddress: u64,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -108,52 +108,54 @@ fn get_services(con: &WMIConnection) {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
+    let com = COMLibrary::new().unwrap();
+
     // baseline: 41ms
     c.bench_function("get_accounts", |b| {
-        let wmi_con = WMIConnection::new(COMLibrary::new().unwrap().into()).unwrap();
+        let wmi_con = WMIConnection::new(com).unwrap();
         b.iter(|| get_accounts(&wmi_con))
     });
 
     // baseline: 13ms
     c.bench_function("get_user_accounts", |b| {
-        let wmi_con = WMIConnection::new(COMLibrary::new().unwrap().into()).unwrap();
+        let wmi_con = WMIConnection::new(com).unwrap();
         b.iter(|| get_user_accounts(&wmi_con))
     });
 
     // baseline: 9ms
     c.bench_function("get_user_accounts_hash_map", |b| {
-        let wmi_con = WMIConnection::new(COMLibrary::new().unwrap().into()).unwrap();
+        let wmi_con = WMIConnection::new(com).unwrap();
         b.iter(|| get_user_accounts_hash_map(&wmi_con))
     });
 
     // baseline: 60ms
     c.bench_function("get_minimal_procs", |b| {
-        let wmi_con = WMIConnection::new(COMLibrary::new().unwrap().into()).unwrap();
+        let wmi_con = WMIConnection::new(com).unwrap();
         b.iter(|| get_minimal_procs(&wmi_con))
     });
 
     // baseline: 68ms
     c.bench_function("get_procs_hash_map", |b| {
-        let wmi_con = WMIConnection::new(COMLibrary::new().unwrap().into()).unwrap();
+        let wmi_con = WMIConnection::new(com).unwrap();
         b.iter(|| get_procs_hash_map(&wmi_con))
     });
 
     // baseline: 9s (**seconds**)
     // after adding AssocClass: 73ms
     c.bench_function("get_users_with_groups", |b| {
-        let wmi_con = WMIConnection::new(COMLibrary::new().unwrap().into()).unwrap();
+        let wmi_con = WMIConnection::new(com).unwrap();
         b.iter(|| get_users_with_groups(&wmi_con))
     });
 
     // baseline: 625ms.
     c.bench_function("get_modules", |b| {
-        let wmi_con = WMIConnection::new(COMLibrary::new().unwrap().into()).unwrap();
+        let wmi_con = WMIConnection::new(com).unwrap();
         b.iter(|| get_modules(&wmi_con))
     });
 
     // baseline: 300ms.
     c.bench_function("get_services", |b| {
-        let wmi_con = WMIConnection::new(COMLibrary::new().unwrap().into()).unwrap();
+        let wmi_con = WMIConnection::new(com).unwrap();
         b.iter(|| get_services(&wmi_con))
     });
 }

--- a/src/bin/wmiq.rs
+++ b/src/bin/wmiq.rs
@@ -1,13 +1,13 @@
-use wmi::{COMLibrary, Variant, WMIConnection};
+use wmi::{COMLibrary, Variant, WMIConnection, WMIResult};
 use std::{collections::HashMap, env::args};
 
-fn main() {
-    let wmi_con = WMIConnection::new(COMLibrary::new().unwrap()).unwrap();
+fn main() -> WMIResult<()> {
+    let wmi_con = WMIConnection::new(COMLibrary::new()?)?;
     let args: Vec<String> = args().collect();
     let query = match args.get(1) {
         None => {
             println!("Expected an argument with a WMI query");
-            return;
+            return Ok(());
         }
         Some(query) => query,
     };
@@ -15,7 +15,7 @@ fn main() {
     let results: Vec<HashMap<String, Variant>> = match wmi_con.raw_query(&query) {
         Err(e) => {
             println!("Couldn't run query {} because of {:?}", query, e);
-            return;
+            return Ok(());
         }
         Ok(results) => results,
     };
@@ -24,4 +24,6 @@ fn main() {
         println!("Result {}", i);
         println!("{:#?}", res);
     }
+
+    Ok(())
 }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -301,9 +301,11 @@ mod tests {
     use crate::{tests::fixtures::*, FilterValue, WMIError};
     use winapi::{shared::ntdef::HRESULT, um::wbemcli::WBEM_E_UNPARSABLE_QUERY};
     use std::{collections::HashMap, time::Duration};
-    use chrono::Datelike;
     use serde::Deserialize;
     use futures::StreamExt;
+
+    #[cfg(feature = "chrono")]
+    use chrono::Datelike;
 
     const TEST_QUERY: &str = "SELECT * FROM __InstanceModificationEvent WHERE TargetInstance ISA 'Win32_LocalTime'";
 


### PR DESCRIPTION
I wanted to do some quick housekeeping for this crate.

A quick rundown of what I did:
- I added names to steps in workflows. The test summaries were unreadable, so this is a really useful change.
- I changed how the test workflow runs.
- I removed unused deps and cleaned up a little `cargo.toml` file.
- And I fixed the benchmark.

The test workflow now, after finishing builds, runs tests with all targets with default features (so with the chrono crate), and then it only runs tests again, but now with the time crate. Lastly, it runs doc tests (with the "test" feature).