### PR TITLE
feat: properly handle cancellation of async notification

### DIFF
--- a/src/async_query.rs
+++ b/src/async_query.rs
@@ -1,5 +1,5 @@
 use crate::{
-    query_sink::{AsyncQueryResultStream, IWbemObjectSink, QuerySink},
+    query_sink::{AsyncQueryResultStream, IWbemObjectSink, QuerySink, AsyncQueryResultStreamInner},
     query::{FilterValue, build_query},
     result_enumerator::IWbemClassWrapper,
     connection::WMIConnection,
@@ -28,7 +28,7 @@ impl WMIConnection {
         let query_language = BStr::from_str("WQL")?;
         let query = BStr::from_str(query.as_ref())?;
 
-        let stream = AsyncQueryResultStream::new();
+        let stream = AsyncQueryResultStreamInner::new();
         // The internal RefCount has initial value = 1.
         let p_sink: ClassAllocation<QuerySink> = QuerySink::allocate(stream.clone());
         let p_sink_handle = IWbemObjectSink::from(&**p_sink);
@@ -45,7 +45,7 @@ impl WMIConnection {
             ))?;
         }
 
-        Ok(stream)
+        Ok(AsyncQueryResultStream::new(stream, p_sink))
     }
 
     /// Async version of [`raw_query`](WMIConnection#method.raw_query)

--- a/src/async_query.rs
+++ b/src/async_query.rs
@@ -45,7 +45,7 @@ impl WMIConnection {
             ))?;
         }
 
-        Ok(AsyncQueryResultStream::new(stream, p_sink))
+        Ok(AsyncQueryResultStream::new(stream, self.clone(), p_sink))
     }
 
     /// Async version of [`raw_query`](WMIConnection#method.raw_query)

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -226,6 +226,24 @@ fn create_services(loc: *const IWbemLocator, path: &str) -> WMIResult<NonNull<IW
     Ok(p_svc)
 }
 
+impl Clone for WMIConnection {
+    fn clone(&self) -> Self {
+        // Creates a copy of the pointer and calls
+        // [AddRef](https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-addref)
+        // to increment Reference Count.
+        //
+        // # Safety
+        // See [Managing the lifetime of an object](https://docs.microsoft.com/en-us/windows/win32/learnwin32/managing-the-lifetime-of-an-object)
+        // and [Rules for managing Ref count](https://docs.microsoft.com/en-us/windows/win32/com/rules-for-managing-reference-counts)
+        unsafe { self.p_svc.as_ref().AddRef() };
+
+        Self {
+            _com_con: self._com_con,
+            p_svc: self.p_svc,
+        }
+    }
+}
+
 impl Drop for WMIConnection {
     fn drop(&mut self) {
         unsafe {

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,5 +1,5 @@
 use crate::{
-    query_sink::{AsyncQueryResultStream, QuerySink, IWbemObjectSink},
+    query_sink::{AsyncQueryResultStream, QuerySink, IWbemObjectSink, AsyncQueryResultStreamInner},
     result_enumerator::{QueryResultEnumerator, IWbemClassWrapper},
     bstr::BStr,
     utils::check_hres,
@@ -153,7 +153,7 @@ impl WMIConnection {
         let query_language = BStr::from_str("WQL")?;
         let query = BStr::from_str(query.as_ref())?;
 
-        let stream = AsyncQueryResultStream::new();
+        let stream = AsyncQueryResultStreamInner::new();
         // The internal RefCount has initial value = 1.
         let p_sink: ClassAllocation<QuerySink> = QuerySink::allocate(stream.clone());
         let p_sink_handle = IWbemObjectSink::from(&**p_sink);
@@ -170,7 +170,7 @@ impl WMIConnection {
             ))?;
         }
 
-        Ok(stream)
+        Ok(AsyncQueryResultStream::new(stream, p_sink))
     }
 
     /// Async version of [`raw_notification`](WMIConnection#method.raw_notification)

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -170,7 +170,7 @@ impl WMIConnection {
             ))?;
         }
 
-        Ok(AsyncQueryResultStream::new(stream, p_sink))
+        Ok(AsyncQueryResultStream::new(stream, self.clone(), p_sink))
     }
 
     /// Async version of [`raw_notification`](WMIConnection#method.raw_notification)


### PR DESCRIPTION
To end an async notification, CancelAsyncCall must be called, so that the refcount on the sink that is kept internally can be released.

There isn't really a better solution than adding a new object that implements this cancel on drop. Trying to add it to the stream would have a lifetime bound on it, and would cause issues with the async queries that are not notifications.

Fixes #65