### PR TITLE
Add `cargo fmt` and `cargo clippy` to CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,9 +7,7 @@ jobs:
     name: Build
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v3
 
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -47,9 +45,7 @@ jobs:
     name: Run tests
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v3
 
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-name: test
+name: check
 
 on: [push, pull_request]
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,8 +3,8 @@ name: check
 on: [push, pull_request]
 
 jobs:
-  test:
-    name: Run tests
+  build:
+    name: Build
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
@@ -42,6 +42,19 @@ jobs:
         with:
           command: build
           args: --all-features
+
+  test:
+    name: Run tests
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
 
       # Test on default features
       - name: Test - All targets

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -90,3 +90,21 @@ jobs:
         with:
           command: fmt
           args: --check
+
+  clippy:
+    name: Clippy
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+
+      - name: Run clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -72,3 +72,21 @@ jobs:
         with:
           command: test
           args: --doc --features=test
+
+  fmt:
+    name: Rustfmt
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+
+      - name: Run format check
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --check

--- a/src/async_query.rs
+++ b/src/async_query.rs
@@ -1,15 +1,15 @@
 use crate::{
-    query_sink::{AsyncQueryResultStream, QuerySink, AsyncQueryResultStreamInner},
-    query::{FilterValue, build_query},
-    result_enumerator::IWbemClassWrapper,
     connection::WMIConnection,
+    query::{build_query, FilterValue},
+    query_sink::{AsyncQueryResultStream, AsyncQueryResultStreamInner, QuerySink},
+    result_enumerator::IWbemClassWrapper,
     WMIResult,
 };
 use futures::stream::{Stream, StreamExt, TryStreamExt};
-use windows::core::BSTR;
-use windows::Win32::System::Wmi::{WBEM_FLAG_BIDIRECTIONAL, IWbemObjectSink};
-use std::collections::HashMap;
 use serde::de;
+use std::collections::HashMap;
+use windows::core::BSTR;
+use windows::Win32::System::Wmi::{IWbemObjectSink, WBEM_FLAG_BIDIRECTIONAL};
 
 ///
 /// ### Additional async methods
@@ -28,7 +28,9 @@ impl WMIConnection {
 
         let stream = AsyncQueryResultStreamInner::new();
         // The internal RefCount has initial value = 1.
-        let p_sink = QuerySink { stream: stream.clone() };
+        let p_sink = QuerySink {
+            stream: stream.clone(),
+        };
         let p_sink_handle: IWbemObjectSink = p_sink.into();
 
         unsafe {
@@ -43,7 +45,11 @@ impl WMIConnection {
             )?;
         }
 
-        Ok(AsyncQueryResultStream::new(stream, self.clone(), p_sink_handle))
+        Ok(AsyncQueryResultStream::new(
+            stream,
+            self.clone(),
+            p_sink_handle,
+        ))
     }
 
     /// Async version of [`raw_query`](WMIConnection#method.raw_query)
@@ -133,8 +139,8 @@ impl WMIConnection {
 mod tests {
     use crate::{tests::fixtures::*, Variant};
     use futures::stream::{self, StreamExt};
-    use std::collections::HashMap;
     use serde::Deserialize;
+    use std::collections::HashMap;
 
     #[async_std::test]
     async fn async_it_works_async() {

--- a/src/benches/benchmark.rs
+++ b/src/benches/benchmark.rs
@@ -1,9 +1,9 @@
 #![allow(non_snake_case)]
 
-use wmi::{COMLibrary, Variant, WMIConnection};
-use criterion::{Criterion, criterion_group};
+use criterion::{criterion_group, Criterion};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use wmi::{COMLibrary, Variant, WMIConnection};
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename = "Win32_Account")]

--- a/src/bin/wmiq.rs
+++ b/src/bin/wmiq.rs
@@ -1,5 +1,5 @@
-use wmi::{COMLibrary, Variant, WMIConnection, WMIResult};
 use std::{collections::HashMap, env::args};
+use wmi::{COMLibrary, Variant, WMIConnection, WMIResult};
 
 fn main() -> WMIResult<()> {
     let wmi_con = WMIConnection::new(COMLibrary::new()?)?;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,16 +1,20 @@
 use crate::utils::WMIResult;
 use crate::WMIError;
-use std::marker::PhantomData;
 use log::debug;
-use windows::Win32::Foundation::RPC_E_TOO_LATE;
-use windows::Win32::System::Wmi::{IWbemLocator, IWbemServices, WBEM_FLAG_CONNECT_USE_MAX_WAIT, WbemLocator};
-use windows::Win32::System::Com::{CoSetProxyBlanket, CoCreateInstance, CLSCTX_INPROC_SERVER, RPC_C_AUTHN_LEVEL_CALL};
-use windows::Win32::System::Rpc::{RPC_C_AUTHN_WINNT, RPC_C_AUTHZ_NONE};
-use windows::Win32::System::Com::{
-    CoInitializeEx, COINIT_MULTITHREADED, CoInitializeSecurity, RPC_C_AUTHN_LEVEL_DEFAULT,
-    RPC_C_IMP_LEVEL_IMPERSONATE, EOAC_NONE
-};
+use std::marker::PhantomData;
 use windows::core::BSTR;
+use windows::Win32::Foundation::RPC_E_TOO_LATE;
+use windows::Win32::System::Com::{
+    CoCreateInstance, CoSetProxyBlanket, CLSCTX_INPROC_SERVER, RPC_C_AUTHN_LEVEL_CALL,
+};
+use windows::Win32::System::Com::{
+    CoInitializeEx, CoInitializeSecurity, COINIT_MULTITHREADED, EOAC_NONE,
+    RPC_C_AUTHN_LEVEL_DEFAULT, RPC_C_IMP_LEVEL_IMPERSONATE,
+};
+use windows::Win32::System::Rpc::{RPC_C_AUTHN_WINNT, RPC_C_AUTHZ_NONE};
+use windows::Win32::System::Wmi::{
+    IWbemLocator, IWbemServices, WbemLocator, WBEM_FLAG_CONNECT_USE_MAX_WAIT,
+};
 
 /// A marker to indicate that the current thread was `CoInitialize`d.
 ///
@@ -96,7 +100,7 @@ impl COMLibrary {
     fn init_security(&self) -> WMIResult<()> {
         unsafe {
             CoInitializeSecurity(
-                    None,
+                None,
                 -1, // let COM choose.
                 None,
                 None,
@@ -144,10 +148,7 @@ impl WMIConnection {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn with_namespace_path(
-        namespace_path: &str,
-        com_lib: COMLibrary,
-    ) -> WMIResult<Self> {
+    pub fn with_namespace_path(namespace_path: &str, com_lib: COMLibrary) -> WMIResult<Self> {
         let loc = create_locator()?;
         let svc = create_services(&loc, namespace_path)?;
 
@@ -166,8 +167,8 @@ impl WMIConnection {
         unsafe {
             CoSetProxyBlanket(
                 &self.svc,
-                RPC_C_AUTHN_WINNT,           // RPC_C_AUTHN_xxx
-                RPC_C_AUTHZ_NONE,            // RPC_C_AUTHZ_xxx
+                RPC_C_AUTHN_WINNT, // RPC_C_AUTHN_xxx
+                RPC_C_AUTHZ_NONE,  // RPC_C_AUTHZ_xxx
                 None,
                 RPC_C_AUTHN_LEVEL_CALL,      // RPC_C_AUTHN_LEVEL_xxx
                 RPC_C_IMP_LEVEL_IMPERSONATE, // RPC_C_IMP_LEVEL_xxx
@@ -183,13 +184,7 @@ impl WMIConnection {
 fn create_locator() -> WMIResult<IWbemLocator> {
     debug!("Calling CoCreateInstance for CLSID_WbemLocator");
 
-    let loc = unsafe {
-        CoCreateInstance(
-            &WbemLocator,
-            None,
-            CLSCTX_INPROC_SERVER,
-        )?
-    };
+    let loc = unsafe { CoCreateInstance(&WbemLocator, None, CLSCTX_INPROC_SERVER)? };
 
     debug!("Got locator {:?}", loc);
 

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1,7 +1,7 @@
 use crate::WMIError;
-use std::{str::FromStr, fmt};
 use chrono::prelude::*;
 use serde::{de, ser};
+use std::{fmt, str::FromStr};
 
 /// A wrapper type around `chrono`'s `DateTime` (if the `chrono` feature is active. ), which supports parsing from WMI-format strings.
 #[derive(Debug)]

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -17,7 +17,7 @@ impl FromStr for WMIDateTime {
 
         let (datetime_part, tz_part) = s.split_at(21);
         let tz_min: i32 = tz_part.parse()?;
-        let tz = FixedOffset::east(tz_min * 60);
+        let tz = FixedOffset::east_opt(tz_min * 60).unwrap();
         let dt = tz.datetime_from_str(datetime_part, "%Y%m%d%H%M%S.%f")?;
 
         Ok(Self(dt))

--- a/src/datetime_time.rs
+++ b/src/datetime_time.rs
@@ -1,13 +1,10 @@
 use crate::WMIError;
+use serde::{de, ser};
+use std::{fmt, str::FromStr};
 use time::{
-    format_description::FormatItem,
-    parsing::Parsed,
-    macros::format_description,
-    PrimitiveDateTime,
+    format_description::FormatItem, macros::format_description, parsing::Parsed, PrimitiveDateTime,
     UtcOffset,
 };
-use std::{str::FromStr, fmt};
-use serde::{de, ser};
 
 /// A wrapper type around `time`'s `OffsetDateTime` (if the
 // `time` feature is active), which supports parsing from WMI-format strings.

--- a/src/de/meta.rs
+++ b/src/de/meta.rs
@@ -1,4 +1,4 @@
-use serde::de::{value::Error, self, Deserialize, Deserializer, Visitor};
+use serde::de::{self, value::Error, Deserialize, Deserializer, Visitor};
 use serde::forward_to_deserialize_any;
 
 /// Return the fields of a struct.

--- a/src/de/variant_de.rs
+++ b/src/de/variant_de.rs
@@ -1,6 +1,6 @@
-use crate::{variant::Variant, de::wbem_class_de::Deserializer, WMIError};
-use serde::{de, Deserialize, forward_to_deserialize_any};
-use std::{vec::IntoIter, fmt};
+use crate::{de::wbem_class_de::Deserializer, variant::Variant, WMIError};
+use serde::{de, forward_to_deserialize_any, Deserialize};
+use std::{fmt, vec::IntoIter};
 
 #[derive(Debug)]
 struct SeqAccess {
@@ -46,7 +46,10 @@ impl<'de> serde::Deserializer<'de> for Variant {
             Variant::Array(v) => visitor.visit_seq(SeqAccess {
                 data: v.into_iter(),
             }),
-            _ => Err(WMIError::InvalidDeserializationVariantError(format!("{:?}", self))),
+            _ => Err(WMIError::InvalidDeserializationVariantError(format!(
+                "{:?}",
+                self
+            ))),
         }
     }
 
@@ -61,12 +64,19 @@ impl<'de> serde::Deserializer<'de> for Variant {
         }
     }
 
-    fn deserialize_struct<V>(self, name: &'static str, fields: &'static [&'static str], visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
     {
         match self {
-            Variant::Object(o) => Deserializer::from_wbem_class_obj(o).deserialize_struct(name, fields, visitor),
+            Variant::Object(o) => {
+                Deserializer::from_wbem_class_obj(o).deserialize_struct(name, fields, visitor)
+            }
             _ => self.deserialize_any(visitor),
         }
     }

--- a/src/de/wbem_class_de.rs
+++ b/src/de/wbem_class_de.rs
@@ -1,6 +1,9 @@
 use crate::{result_enumerator::IWbemClassWrapper, WMIError, WMIResult};
 use serde::{
-    de::{self, DeserializeOwned, DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, Unexpected, VariantAccess, Visitor},
+    de::{
+        self, DeserializeOwned, DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess,
+        Unexpected, VariantAccess, Visitor,
+    },
     forward_to_deserialize_any,
 };
 use std::iter::Peekable;

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -1,6 +1,6 @@
 use crate::WMIError;
-use std::{str::FromStr, time::Duration, fmt};
 use serde::{de, ser};
+use std::{fmt, str::FromStr, time::Duration};
 
 /// A wrapper type around Duration, which supports parsing from WMI-format strings.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,7 +298,7 @@ pub use datetime::WMIDateTime;
 pub use datetime_time::WMIOffsetDateTime;
 
 pub use duration::WMIDuration;
-pub use query::{FilterValue, build_query, build_notification_query};
+pub use query::{build_notification_query, build_query, FilterValue};
 pub use utils::{WMIError, WMIResult};
 pub use variant::Variant;
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -7,11 +7,10 @@ use crate::{
 };
 use log::trace;
 use serde::de;
-use windows::Win32::System::Wmi::{WBEM_FLAG_FORWARD_ONLY, WBEM_FLAG_RETURN_IMMEDIATELY, WBEM_FLAG_RETURN_WBEM_COMPLETE};
+use std::{collections::HashMap, time::Duration};
 use windows::core::BSTR;
-use std::{
-    collections::HashMap,
-    time::Duration,
+use windows::Win32::System::Wmi::{
+    WBEM_FLAG_FORWARD_ONLY, WBEM_FLAG_RETURN_IMMEDIATELY, WBEM_FLAG_RETURN_WBEM_COMPLETE,
 };
 
 pub enum FilterValue {
@@ -415,7 +414,7 @@ impl WMIConnection {
                 WBEM_FLAG_RETURN_WBEM_COMPLETE.0 as _,
                 None,
                 Some(&mut pcls_obj),
-                None
+                None,
             )?;
         }
 
@@ -578,8 +577,8 @@ impl WMIConnection {
 mod tests {
     use super::*;
     use serde::Deserialize;
-    use windows::Win32::System::Wmi::WBEM_E_INVALID_QUERY;
     use std::collections::HashMap;
+    use windows::Win32::System::Wmi::WBEM_E_INVALID_QUERY;
 
     use crate::tests::fixtures::*;
     use crate::{Variant, WMIError};

--- a/src/safearray.rs
+++ b/src/safearray.rs
@@ -1,8 +1,13 @@
-use crate::{utils::{WMIError, WMIResult}, Variant};
-use std::{iter::Iterator, slice, ptr::null_mut};
-use windows::Win32::System::Com::{self, SAFEARRAY, VT_BSTR, VARENUM};
-use windows::Win32::System::Ole::{SafeArrayGetLBound, SafeArrayGetUBound, SafeArrayAccessData, SafeArrayUnaccessData};
+use crate::{
+    utils::{WMIError, WMIResult},
+    Variant,
+};
+use std::{iter::Iterator, ptr::null_mut, slice};
 use windows::core::BSTR;
+use windows::Win32::System::Com::{self, SAFEARRAY, VARENUM, VT_BSTR};
+use windows::Win32::System::Ole::{
+    SafeArrayAccessData, SafeArrayGetLBound, SafeArrayGetUBound, SafeArrayUnaccessData,
+};
 
 #[derive(Debug)]
 pub struct SafeArrayAccessor<'a, T> {
@@ -86,14 +91,8 @@ pub fn safe_array_to_vec_of_strings(arr: &SAFEARRAY) -> WMIResult<Vec<String>> {
 /// # Safety
 ///
 /// The caller must ensure that the array is valid.
-pub fn safe_array_to_vec(
-    arr: &SAFEARRAY,
-    item_type: VARENUM,
-) -> WMIResult<Vec<Variant>> {
-    fn copy_type_to_vec<T, F>(
-        arr: &SAFEARRAY,
-        variant_builder: F,
-    ) -> WMIResult<Vec<Variant>>
+pub fn safe_array_to_vec(arr: &SAFEARRAY, item_type: VARENUM) -> WMIResult<Vec<Variant>> {
+    fn copy_type_to_vec<T, F>(arr: &SAFEARRAY, variant_builder: F) -> WMIResult<Vec<Variant>>
     where
         T: Copy,
         F: Fn(T) -> Variant,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{COMLibrary, WMIConnection, WMIResult, WMIError};
+use crate::{COMLibrary, WMIConnection, WMIError, WMIResult};
 
 pub mod fixtures {
     use super::*;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
-use std::fmt::{Debug, Display};
 use serde::{de, ser};
+use std::fmt::{Debug, Display};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -49,7 +49,9 @@ pub enum WMIError {
 
 impl From<windows::core::Error> for WMIError {
     fn from(value: windows::core::Error) -> Self {
-        Self::HResultError { hres: value.code().0 }
+        Self::HResultError {
+            hres: value.code().0,
+        }
     }
 }
 

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -1,15 +1,12 @@
 use crate::{
-    result_enumerator::IWbemClassWrapper,
-    safearray::safe_array_to_vec,
-    WMIError,
-    WMIResult,
+    result_enumerator::IWbemClassWrapper, safearray::safe_array_to_vec, WMIError, WMIResult,
 };
-use std::convert::TryFrom;
 use serde::Serialize;
-use windows::Win32::Foundation::{VARIANT_FALSE, VARIANT_TRUE};
-use windows::Win32::System::Wmi::{self, CIMTYPE_ENUMERATION, IWbemClassObject};
-use windows::Win32::System::Com::{self, VARIANT, VT_ARRAY, VT_TYPEMASK, VARENUM};
+use std::convert::TryFrom;
 use windows::core::{IUnknown, Interface, BSTR};
+use windows::Win32::Foundation::{VARIANT_FALSE, VARIANT_TRUE};
+use windows::Win32::System::Com::{self, VARENUM, VARIANT, VT_ARRAY, VT_TYPEMASK};
+use windows::Win32::System::Wmi::{self, IWbemClassObject, CIMTYPE_ENUMERATION};
 
 #[derive(Debug, PartialEq, Serialize)]
 #[serde(untagged)]
@@ -171,7 +168,7 @@ impl Variant {
                 let unk = unsafe { &vt.Anonymous.Anonymous.Anonymous.punkVal };
                 let ptr = unk.as_ref().ok_or(WMIError::NullPointerResult)?;
                 Variant::Unknown(IUnknownWrapper::new(ptr.clone()))
-            },
+            }
             _ => return Err(WMIError::ConvertError(variant_type.0)),
         };
 
@@ -194,7 +191,8 @@ impl Variant {
             match self {
                 // If we got an array, we just need to convert it's elements.
                 Variant::Array(arr) => {
-                    return Variant::Array(arr).convert_into_cim_type(CIMTYPE_ENUMERATION(cim_type.0 & 0xff))
+                    return Variant::Array(arr)
+                        .convert_into_cim_type(CIMTYPE_ENUMERATION(cim_type.0 & 0xff))
                 }
                 Variant::Empty | Variant::Null => {
                     return Ok(Variant::Array(vec![]));
@@ -257,7 +255,7 @@ impl Variant {
                     .collect::<Result<Vec<_>, WMIError>>()?;
 
                 Variant::Array(converted_variants)
-            },
+            }
             Variant::Unknown(u) => {
                 if cim_type == Wmi::CIM_OBJECT {
                     Variant::Object(u.to_wbem_class_obj()?)
@@ -265,9 +263,9 @@ impl Variant {
                     return Err(WMIError::ConvertVariantError(format!(
                         "A unknown Variant cannot be turned into a CIMTYPE {:?}",
                         cim_type,
-                    )))
+                    )));
                 }
-            },
+            }
             Variant::Object(o) => Variant::Object(o),
         };
 
@@ -303,7 +301,7 @@ impl Serialize for IUnknownWrapper {
     ///
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer
+        S: serde::Serializer,
     {
         serializer.serialize_unit()
     }


### PR DESCRIPTION
The following changes were made to the CI script:
- Rename the script to `check` since `test` does not properly reflect its role.
- Split the jobs for building and testing
- Add the `cargo fmt` check
  - Ran `cargo fmt` on the entire project to pass this check
- Add the `cargo clippy` check
  - Fix the following warning in *datetime.rs*:
    > use of deprecated associated function `chrono::FixedOffset::east`: use `east_opt()` instead