### PR TITLE
Make filter `#[non_exhaustive]`

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -13,6 +13,7 @@ use windows::Win32::System::Wmi::{
     WBEM_FLAG_FORWARD_ONLY, WBEM_FLAG_RETURN_IMMEDIATELY, WBEM_FLAG_RETURN_WBEM_COMPLETE,
 };
 
+#[non_exhaustive]
 pub enum FilterValue {
     Bool(bool),
     Number(i64),


### PR DESCRIPTION
> Outside of the defining crate, types annotated with non_exhaustive have limitations that preserve backwards compatibility when new fields or variants are added.