### PR TITLE
Add support for enum fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wmi"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Ohad Ravid <ohad.rv@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/de/variant_de.rs
+++ b/src/de/variant_de.rs
@@ -81,10 +81,27 @@ impl<'de> serde::Deserializer<'de> for Variant {
         }
     }
 
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            Variant::Object(o) => {
+                Deserializer::from_wbem_class_obj(o).deserialize_enum(name, fields, visitor)
+            }
+            _ => self.deserialize_any(visitor),
+        }
+    }
+
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         bytes byte_buf unit unit_struct newtype_struct seq tuple
-        tuple_struct map enum identifier ignored_any
+        tuple_struct map identifier ignored_any
     }
 }
 


### PR DESCRIPTION
This PR makes it possible to have fields which are enums containing other WMI objects, like so:

```rust
#[derive(Deserialize, Debug)]
struct Win32_Process {}

#[derive(Deserialize, Debug)]
struct Win32_Thread {}

#[derive(Deserialize, Debug)]
enum Instance {
    #[serde(rename = "Win32_Process")]
    Process(Win32_Process),
    #[serde(rename = "Win32_Thread")]
    Thread(Win32_Thread),
}

#[derive(Deserialize, Debug)]
struct __InstanceCreationEvent {
    TargetInstance: Instance,
}

let mut filters_process = HashMap::new();

filters_process.insert(
    "TargetInstance".to_owned(),
    FilterValue::is_a::<Win32_Process>().unwrap(),
);

let mut instances_iter = wmi_con
    .filtered_notification::<__InstanceCreationEvent>(
        &filters_process,
        Some(Duration::from_secs(1)),
    )
    .unwrap();
```