### PR TITLE
Unit enum support

### DIFF
--- a/src/de/variant_de.rs
+++ b/src/de/variant_de.rs
@@ -1,5 +1,8 @@
 use crate::{de::wbem_class_de::Deserializer, variant::Variant, WMIError};
-use serde::{de::{self, IntoDeserializer}, forward_to_deserialize_any, Deserialize};
+use serde::{
+    de::{self, IntoDeserializer},
+    forward_to_deserialize_any, Deserialize,
+};
 use std::{fmt, vec::IntoIter};
 
 #[derive(Debug)]
@@ -94,9 +97,9 @@ impl<'de> serde::Deserializer<'de> for Variant {
             Variant::Object(o) => {
                 Deserializer::from_wbem_class_obj(o).deserialize_enum(name, variants, visitor)
             }
-            Variant::String(str) => {
-                str.into_deserializer().deserialize_enum(name, variants, visitor)
-            }
+            Variant::String(str) => str
+                .into_deserializer()
+                .deserialize_enum(name, variants, visitor),
             _ => self.deserialize_any(visitor),
         }
     }

--- a/src/de/wbem_class_de.rs
+++ b/src/de/wbem_class_de.rs
@@ -494,19 +494,42 @@ mod tests {
 
         #[derive(Deserialize, Debug, PartialEq, Eq)]
         enum Status {
+            SomeValue,
             OK,
+            SomeOtherValue,
         }
-        
-        #[derive(Deserialize, Debug)] 
+
+        #[derive(Deserialize, Debug)]
         struct Win32_OperatingSystem {
             Status: Status,
         }
 
-        let os: Win32_OperatingSystem = wmi_con
-            .get()
-            .unwrap();
+        let os: Win32_OperatingSystem = wmi_con.get().unwrap();
 
         assert_eq!(os.Status, Status::OK);
     }
 
+    #[test]
+    fn it_fail_to_desr_unit_enum_field_from_unexpected_string() {
+        let wmi_con = wmi_con();
+
+        #[derive(Deserialize, Debug, PartialEq, Eq)]
+        enum Status {
+            Potato,
+        }
+
+        #[derive(Deserialize, Debug)]
+        struct Win32_OperatingSystem {
+            Status: Status,
+        }
+
+        let res: Result<Win32_OperatingSystem, WMIError> = wmi_con.get();
+
+        let err = res.err().unwrap();
+
+        assert_eq!(
+            format!("{}", err),
+            "unknown variant `OK`, expected `Potato`"
+        )
+    }
 }


### PR DESCRIPTION
- Fix `fmt` error
- Add fail-to-desr test, and other values to desr test