### PR TITLE
Improve Variant and SafeArray implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wmi"
-version = "0.13.4"
+version = "0.14.0"
 authors = ["Ohad Ravid <ohad.rv@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/de/wbem_class_de.rs
+++ b/src/de/wbem_class_de.rs
@@ -221,6 +221,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer {
 
 #[allow(non_snake_case)]
 #[allow(non_camel_case_types)]
+#[allow(dead_code)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/query.rs
+++ b/src/query.rs
@@ -592,6 +592,7 @@ impl WMIConnection {
 
 #[allow(non_snake_case)]
 #[allow(non_camel_case_types)]
+#[allow(dead_code)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/result_enumerator.rs
+++ b/src/result_enumerator.rs
@@ -71,8 +71,6 @@ impl IWbemClassWrapper {
             let property_value = Variant::from_variant(&vt_prop)?
                 .convert_into_cim_type(CIMTYPE_ENUMERATION(cim_type))?;
 
-            VariantClear(&mut vt_prop)?;
-
             Ok(property_value)
         }
     }

--- a/src/result_enumerator.rs
+++ b/src/result_enumerator.rs
@@ -11,7 +11,6 @@ use serde::{
 use std::ptr;
 use windows::core::VARIANT;
 use windows::Win32::System::Ole::SafeArrayDestroy;
-use windows::Win32::System::Variant::VariantClear;
 use windows::Win32::System::Wmi::{
     IEnumWbemClassObject, IWbemClassObject, CIMTYPE_ENUMERATION, WBEM_FLAG_ALWAYS,
     WBEM_FLAG_NONSYSTEM_ONLY, WBEM_INFINITE,
@@ -46,7 +45,7 @@ impl IWbemClassWrapper {
             )
         }?;
 
-        let res = safe_array_to_vec_of_strings(unsafe { &*p_names });
+        let res = unsafe { safe_array_to_vec_of_strings(unsafe { &*p_names }) };
 
         unsafe { SafeArrayDestroy(p_names) }?;
 
@@ -149,8 +148,8 @@ impl<'a> Iterator for QueryResultEnumerator<'a> {
             &objs[0]
         );
 
-        let mut objs = objs.into_iter();
-        let pcls_ptr = objs.next().unwrap().ok_or(WMIError::NullPointerResult);
+        let [obj] = objs;
+        let pcls_ptr = obj.ok_or(WMIError::NullPointerResult);
 
         match pcls_ptr {
             Err(e) => Some(Err(e)),


### PR DESCRIPTION
Safety:
- In `safearray`: Now `SafeArrayAccessor::new` and `safe_array_to_vec{_of_strings}` are `unsafe`, as it is the caller's responsibility to pass valid arrays.
- `SafeArrayAccessor` now exposes an iterator over the array (and not a slice), based on the data pointer+element count (vs the lower/upper bounds)

Other changes:
- `Variant::from_variant` will now use `windows-rs`'s `VARIANT::to_string`