### PR TITLE
Add support for setting IWbemContext

### DIFF
--- a/src/async_query.rs
+++ b/src/async_query.rs
@@ -40,7 +40,7 @@ impl WMIConnection {
                 &query_language,
                 &query,
                 WBEM_FLAG_BIDIRECTIONAL,
-                &self.ctx,
+                &self.ctx.0,
                 &p_sink_handle,
             )?;
         }

--- a/src/async_query.rs
+++ b/src/async_query.rs
@@ -40,7 +40,7 @@ impl WMIConnection {
                 &query_language,
                 &query,
                 WBEM_FLAG_BIDIRECTIONAL,
-                None,
+                &self.ctx,
                 &p_sink_handle,
             )?;
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+
+use serde::Serialize;
+use windows_core::{BSTR, VARIANT};
+
+use crate::{WMIConnection, WMIResult};
+
+#[derive(Debug, PartialEq, Serialize, Clone)]
+#[serde(untagged)]
+pub enum ContextValueType {
+    String(String),
+    I4(i32),
+    R8(f64),
+    Bool(bool),
+}
+
+impl From<ContextValueType> for VARIANT {
+    fn from(value: ContextValueType) -> Self {
+        match value {
+            ContextValueType::Bool(b) => Self::from(b),
+            ContextValueType::I4(i4) => Self::from(i4),
+            ContextValueType::R8(r8) => Self::from(r8),
+            ContextValueType::String(str) => Self::from(BSTR::from(str)),
+        }
+    }
+}
+
+impl WMIConnection {
+    /// Sets the specified named context values for use in providing additional context information to queries.
+    ///
+    /// Note the context values will persist across subsequent queries until [`WMIConnection::clear_ctx_values`] is called.
+    pub fn set_ctx_values(
+        &mut self,
+        ctx_values: HashMap<String, ContextValueType>,
+    ) -> WMIResult<()> {
+        for (k, v) in ctx_values {
+            let key = BSTR::from(k);
+            let value = v.clone().into();
+            unsafe { self.ctx.SetValue(&key, 0, &value)? };
+        }
+
+        Ok(())
+    }
+
+    /// Clears all named values from the underlying context object.
+    pub fn clear_ctx_values(&mut self) -> WMIResult<()> {
+        unsafe { self.ctx.DeleteAll().map_err(Into::into) }
+    }
+}
+
+macro_rules! impl_from_type {
+    ($target_type:ty, $variant:ident) => {
+        impl From<$target_type> for ContextValueType {
+            fn from(value: $target_type) -> Self {
+                Self::$variant(value.into())
+            }
+        }
+    };
+}
+
+impl_from_type!(&str, String);
+impl_from_type!(i32, I4);
+impl_from_type!(f64, R8);
+impl_from_type!(bool, Bool);
+
+#[allow(non_snake_case)]
+#[allow(non_camel_case_types)]
+#[allow(dead_code)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::COMLibrary;
+    use serde::Deserialize;
+
+    #[test]
+    fn verify_ctx_values_used() {
+        let com_con = COMLibrary::new().unwrap();
+        let mut wmi_con =
+            WMIConnection::with_namespace_path("ROOT\\StandardCimv2", com_con).unwrap();
+
+        #[derive(Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug)]
+        struct MSFT_NetAdapter {
+            InterfaceName: String,
+        }
+
+        let mut orig_adapters = wmi_con.query::<MSFT_NetAdapter>().unwrap();
+        assert!(!orig_adapters.is_empty());
+
+        let mut ctx_values = HashMap::new();
+        ctx_values.insert("IncludeHidden".into(), true.into());
+        wmi_con.set_ctx_values(ctx_values).unwrap();
+
+        // With 'IncludeHidden' set to 'true', expect the response to contain additional adapters
+        let all_adapters = wmi_con.query::<MSFT_NetAdapter>().unwrap();
+        assert!(all_adapters.len() > orig_adapters.len());
+
+        wmi_con.clear_ctx_values().unwrap();
+        let mut adapters = wmi_con.query::<MSFT_NetAdapter>().unwrap();
+        adapters.sort();
+        orig_adapters.sort();
+        assert_eq!(adapters, orig_adapters);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,6 +273,7 @@ pub mod datetime;
 #[cfg(feature = "time")]
 mod datetime_time;
 
+pub mod context;
 pub mod de;
 pub mod duration;
 pub mod query;

--- a/src/query.rs
+++ b/src/query.rs
@@ -279,7 +279,7 @@ impl WMIConnection {
                 &query_language,
                 &query,
                 WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
-                &self.ctx,
+                &self.ctx.0,
             )?
         };
 
@@ -431,7 +431,7 @@ impl WMIConnection {
             self.svc.GetObject(
                 &object_path,
                 WBEM_FLAG_RETURN_WBEM_COMPLETE,
-                None,
+                &self.ctx.0,
                 Some(&mut pcls_obj),
                 None,
             )?;

--- a/src/query.rs
+++ b/src/query.rs
@@ -279,7 +279,7 @@ impl WMIConnection {
                 &query_language,
                 &query,
                 WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
-                None,
+                &self.ctx,
             )?
         };
 
@@ -536,7 +536,7 @@ impl WMIConnection {
 
     /// Query all the associators of type T of the given object.
     /// The `object_path` argument can be provided by querying an object wih it's `__Path` property.
-    /// `AssocClass` must be have the name as the conneting association class between the original object and the results.
+    /// `AssocClass` must be have the name as the connecting association class between the original object and the results.
     /// See <https://docs.microsoft.com/en-us/windows/desktop/cimwin32prov/win32-diskdrivetodiskpartition> for example.
     ///
     /// ```edition2018


### PR DESCRIPTION
Addresses https://github.com/ohadravid/wmi-rs/issues/102

## Motivation

I need some way to programmatically determine the _effective_ firewall status for the `Public` profile. The `MSFT_NetFirewallProfile` class returns this information, but the firewall information is scoped to the local policy. If one has firewall rules configured using a group policy, they will not be reflected in the output.

Thanks to this stackoverflow [post](https://stackoverflow.com/questions/60476758/set-policystore-in-cim-instance), it is possible to query the effective firewall status by specifying `PolicyStore` as `ActiveStore` using the `IWbemContext` interface. This does not seem to be officially documented by Microsoft, but it does seem to work as expected.