### PR TITLE
Add support for executing WMI methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ serde = { version = "1.0", features = ["derive"] }
 futures = { version = "0.3" }
 thiserror = "^2"
 log = "0.4"
+typeid = "1.0.2"
 
 [dev-dependencies]
 async-std = { version = "1.10",  features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ serde = { version = "1.0", features = ["derive"] }
 futures = { version = "0.3" }
 thiserror = "^2"
 log = "0.4"
-typeid = "1.0.2"
 
 [dev-dependencies]
 async-std = { version = "1.10",  features = ["attributes"] }

--- a/src/de/meta.rs
+++ b/src/de/meta.rs
@@ -50,8 +50,19 @@ where
 
         forward_to_deserialize_any! {
             bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes
-            byte_buf option unit unit_struct seq tuple
+            byte_buf option unit seq tuple
             tuple_struct map enum identifier ignored_any
+        }
+
+        fn deserialize_unit_struct<V>(
+            self,
+            name: &'static str,
+            visitor: V,
+        ) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            self.deserialize_struct(name, &[], visitor)
         }
     }
 

--- a/src/de/variant_de.rs
+++ b/src/de/variant_de.rs
@@ -33,7 +33,7 @@ impl<'de> serde::Deserializer<'de> for Variant {
     {
         match self {
             Variant::Null => visitor.visit_none(),
-            Variant::Empty => visitor.visit_none(),
+            Variant::Empty => visitor.visit_unit(),
             Variant::String(s) => visitor.visit_string(s),
             Variant::I1(n) => visitor.visit_i8(n),
             Variant::I2(n) => visitor.visit_i16(n),

--- a/src/de/wbem_class_de.rs
+++ b/src/de/wbem_class_de.rs
@@ -212,9 +212,16 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer {
         visitor.visit_string(class_name)
     }
 
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes
-        byte_buf option unit unit_struct seq tuple
+        byte_buf option unit_struct seq tuple
         tuple_struct ignored_any
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,6 +280,7 @@ pub mod duration;
 pub mod query;
 pub mod result_enumerator;
 pub mod safearray;
+pub mod ser;
 pub mod utils;
 pub mod variant;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,13 @@
 //! [WMI Code Creator]: https://www.microsoft.com/en-us/download/details.aspx?id=8572
 //! [`notification`]: connection/struct.WMIConnection.html#method.notification
 //!
+//! # Executing Methods
+//!
+//! The crate also offers support for executing WMI methods on classes and instances.
+//!
+//! See [`WMIConnection::exec_class_method`], [`WMIConnection::exec_instance_method`] and [`WMIConnection::exec_method_native_wrapper`]
+//! for detailed examples.
+//!
 //! # Internals
 //!
 //! [`WMIConnection`](WMIConnection) is used to create and execute a WMI query, returning

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,6 +277,7 @@ mod datetime_time;
 pub mod context;
 pub mod de;
 pub mod duration;
+pub mod method;
 pub mod query;
 pub mod result_enumerator;
 pub mod safearray;

--- a/src/method.rs
+++ b/src/method.rs
@@ -1,0 +1,198 @@
+use std::collections::HashMap;
+
+use serde::{de, Serialize};
+use windows_core::{BSTR, HSTRING, VARIANT};
+
+use crate::{
+    de::meta::struct_name_and_fields, result_enumerator::IWbemClassWrapper,
+    ser::variant_ser::VariantStructSerializer, WMIConnection, WMIError, WMIResult,
+};
+
+impl WMIConnection {
+    fn exec_method_native_wrapper(
+        &self,
+        method_class: impl AsRef<str>,
+        object_path: impl AsRef<str>,
+        method: impl AsRef<str>,
+        in_params: HashMap<String, VARIANT>,
+    ) -> WMIResult<Option<IWbemClassWrapper>> {
+        let method_class = BSTR::from(method_class.as_ref());
+        let object_path = BSTR::from(object_path.as_ref());
+        let method = BSTR::from(method.as_ref());
+
+        unsafe {
+            let mut class_object = None;
+            self.svc.GetObject(
+                &method_class,
+                Default::default(),
+                &self.ctx.0,
+                Some(&mut class_object),
+                None,
+            )?;
+
+            match class_object {
+                Some(class) => {
+                    let mut input_signature = None;
+                    class.GetMethod(
+                        &method,
+                        Default::default(),
+                        &mut input_signature,
+                        std::ptr::null_mut(),
+                    )?;
+                    let object = match input_signature {
+                        Some(input) => {
+                            let inst = input.SpawnInstance(0)?;
+                            for (wszname, value) in in_params {
+                                inst.Put(&HSTRING::from(wszname), Default::default(), &value, 0)?;
+                            }
+                            Some(inst)
+                        }
+                        None => None,
+                    };
+
+                    let mut output = None;
+                    self.svc.ExecMethod(
+                        &object_path,
+                        &method,
+                        Default::default(),
+                        &self.ctx.0,
+                        object.as_ref(),
+                        Some(&mut output),
+                        None,
+                    )?;
+
+                    match output {
+                        Some(wbem_class_obj) => Ok(Some(IWbemClassWrapper::new(wbem_class_obj))),
+                        None => Ok(None),
+                    }
+                }
+                None => Err(WMIError::ResultEmpty),
+            }
+        }
+    }
+
+    pub fn exec_class_method<MethodClass, In, Out>(
+        &self,
+        method: impl AsRef<str>,
+        in_params: In,
+    ) -> WMIResult<Option<Out>>
+    where
+        MethodClass: de::DeserializeOwned,
+        In: Serialize,
+        Out: de::DeserializeOwned,
+    {
+        let (method_class, _) = struct_name_and_fields::<MethodClass>()?;
+        self.exec_instance_method::<MethodClass, In, Out>(method, method_class, in_params)
+    }
+
+    pub fn exec_instance_method<MethodClass, In, Out>(
+        &self,
+        method: impl AsRef<str>,
+        object_path: impl AsRef<str>,
+        in_params: In,
+    ) -> WMIResult<Option<Out>>
+    where
+        MethodClass: de::DeserializeOwned,
+        In: Serialize,
+        Out: de::DeserializeOwned,
+    {
+        let (method_class, _) = struct_name_and_fields::<MethodClass>()?;
+        let serializer = VariantStructSerializer::new();
+        match in_params.serialize(serializer) {
+            Ok(field_map) => {
+                let field_map: HashMap<String, VARIANT> = field_map
+                    .into_iter()
+                    .filter_map(|(k, v)| match TryInto::<VARIANT>::try_into(v).ok() {
+                        Some(variant) => Some((k, variant)),
+                        None => None,
+                    })
+                    .collect();
+                let output =
+                    self.exec_method_native_wrapper(method_class, object_path, method, field_map);
+
+                match output {
+                    Ok(wbem_class_obj) => match wbem_class_obj {
+                        Some(wbem_class_obj) => Ok(Some(wbem_class_obj.into_desr()?)),
+                        None => Ok(None),
+                    },
+                    Err(e) => Err(e),
+                }
+            }
+            Err(e) => Err(WMIError::ConvertVariantError(e.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::fixtures::wmi_con;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Deserialize)]
+    struct Win32_Process {
+        __Path: String,
+    }
+
+    #[derive(Serialize)]
+    struct CreateParams {
+        CommandLine: String,
+    }
+
+    #[derive(Serialize)]
+    struct TerminateParams {}
+
+    #[derive(Deserialize)]
+    struct TerminateOutput {}
+
+    #[derive(Deserialize)]
+    #[allow(non_snake_case)]
+    struct CreateOutput {
+        ProcessId: u32,
+    }
+
+    #[test]
+    fn it_exec_class_method() {
+        let wmi_con = wmi_con();
+        let in_params = CreateParams {
+            CommandLine: "notepad.exe".to_string(),
+        };
+
+        let out = wmi_con
+            .exec_class_method::<Win32_Process, CreateParams, CreateOutput>("Create", in_params)
+            .unwrap()
+            .unwrap();
+
+        assert!(out.ProcessId != 0);
+    }
+
+    #[test]
+    fn it_exec_instance_method() {
+        // Create notepad instance
+        let wmi_con = wmi_con();
+        let in_params = CreateParams {
+            CommandLine: "notepad.exe".to_string(),
+        };
+        let out = wmi_con
+            .exec_class_method::<Win32_Process, CreateParams, CreateOutput>("Create", in_params)
+            .unwrap()
+            .unwrap();
+
+        let process = wmi_con
+            .raw_query::<Win32_Process>(format!(
+                "SELECT * FROM Win32_Process WHERE ProcessId = {}",
+                out.ProcessId
+            ))
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+
+        let _ = wmi_con
+            .exec_instance_method::<Win32_Process, TerminateParams, TerminateOutput>(
+                "Terminate",
+                process.__Path,
+                TerminateParams {},
+            )
+            .unwrap();
+    }
+}

--- a/src/method.rs
+++ b/src/method.rs
@@ -203,9 +203,8 @@ impl WMIConnection {
     /// }
     ///
     /// fn main() -> WMIResult<()> {
-    ///
     ///     let wmi_con = WMIConnection::new(COMLibrary::new()?)?;
-
+    ///
     ///     let printers: Vec<Win32_Printer> = wmi_con.query()?;
     ///
     ///     for printer in printers {

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,0 +1,1 @@
+pub mod variant_ser;

--- a/src/ser/variant_ser.rs
+++ b/src/ser/variant_ser.rs
@@ -189,6 +189,31 @@ impl Serializer for VariantSerializer {
     }
 }
 
+/// Serializes a struct to a HashMap of key-value pairs, with the key being the field name, and the value being the field value wrapped in a [`Variant`].
+///
+/// VariantStructSerializer only supports serializing fields with basic Rust data types: `i32`, `()`, etc., as well as any of the former in a newtype.
+///
+/// ```edition2021
+/// use serde::Serialize;
+/// use wmi::ser::variant_ser::VariantStructSerializer;
+///
+/// #[derive(Serialize)]
+/// struct TestStruct {
+///     number: f32,
+///     text: String
+/// }
+///
+/// let test_struct = TestStruct {
+///     number: 0.6,
+///     text: "foobar".to_string()
+/// };
+///
+/// let fields = test_struct.serialize(VariantStructSerializer::new()).unwrap();
+///
+/// for (field_name, field_value) in fields {
+///     println!("{field_name}: {field_value:?}");
+/// }
+/// ```
 #[derive(Default)]
 pub struct VariantStructSerializer {
     variant_map: HashMap<String, Variant>,

--- a/src/ser/variant_ser.rs
+++ b/src/ser/variant_ser.rs
@@ -7,15 +7,201 @@ use serde::{
 };
 use thiserror::Error;
 
+macro_rules! serialize_struct_err_stub {
+    ($signature:ident, $type:ty) => {
+        fn $signature(self, _v: $type) -> Result<Self::Ok, Self::Error> {
+            Err(VariantSerializerError::ExpectedStruct)
+        }
+    };
+}
+
+macro_rules! serialize_variant_err_stub {
+    ($signature:ident, $type:ty) => {
+        fn $signature(self, _v: $type) -> Result<Self::Ok, Self::Error> {
+            Err(VariantSerializerError::UnsupportedVariantType(
+                type_name::<$type>().to_string(),
+            ))
+        }
+    };
+}
+
+macro_rules! serialize_variant {
+    ($signature:ident, $type:ty) => {
+        fn $signature(self, v: $type) -> Result<Self::Ok, Self::Error> {
+            Ok(Variant::from(v))
+        }
+    };
+}
+
+struct VariantSerializer {}
+
+impl Serializer for VariantSerializer {
+    type Ok = Variant;
+    type Error = VariantSerializerError;
+
+    type SerializeSeq = Impossible<Self::Ok, Self::Error>;
+    type SerializeTuple = Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleStruct = Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleVariant = Impossible<Self::Ok, Self::Error>;
+    type SerializeMap = Impossible<Self::Ok, Self::Error>;
+    type SerializeStruct = Impossible<Self::Ok, Self::Error>;
+    type SerializeStructVariant = Impossible<Self::Ok, Self::Error>;
+
+    serialize_variant!(serialize_bool, bool);
+    serialize_variant!(serialize_i8, i8);
+    serialize_variant!(serialize_i16, i16);
+    serialize_variant!(serialize_i32, i32);
+    serialize_variant!(serialize_i64, i64);
+    serialize_variant!(serialize_u8, u8);
+    serialize_variant!(serialize_u16, u16);
+    serialize_variant!(serialize_u32, u32);
+    serialize_variant!(serialize_u64, u64);
+    serialize_variant!(serialize_f32, f32);
+    serialize_variant!(serialize_f64, f64);
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Variant::Empty)
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(Variant::from(v.to_string()))
+    }
+
+    serialize_variant_err_stub!(serialize_char, char);
+    serialize_variant_err_stub!(serialize_bytes, &[u8]);
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(VariantSerializerError::UnsupportedVariantType(
+            "None".to_string(),
+        ))
+    }
+
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(VariantSerializerError::UnsupportedVariantType(
+            type_name::<T>().to_string(),
+        ))
+    }
+
+    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(VariantSerializerError::UnsupportedVariantType(
+            name.to_string(),
+        ))
+    }
+
+    fn serialize_unit_variant(
+        self,
+        name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(VariantSerializerError::UnsupportedVariantType(format!(
+            "{variant}::{name}"
+        )))
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(VariantSerializerError::UnsupportedVariantType(
+            type_name::<T>().to_string(),
+        ))
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(VariantSerializerError::UnsupportedVariantType(
+            type_name::<T>().to_string(),
+        ))
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(VariantSerializerError::UnsupportedVariantType(
+            "Sequence".to_string(),
+        ))
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(VariantSerializerError::UnsupportedVariantType(
+            "Tuple".to_string(),
+        ))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(VariantSerializerError::UnsupportedVariantType(
+            name.to_string(),
+        ))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(VariantSerializerError::UnsupportedVariantType(format!(
+            "{variant}::{name}"
+        )))
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(VariantSerializerError::UnsupportedVariantType(
+            "Map".to_string(),
+        ))
+    }
+
+    fn serialize_struct(
+        self,
+        name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(VariantSerializerError::UnsupportedVariantType(
+            name.to_string(),
+        ))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(VariantSerializerError::UnsupportedVariantType(format!(
+            "{variant}::{name}"
+        )))
+    }
+}
+
 pub struct VariantStructSerializer {
     variant_map: HashMap<String, Variant>,
 }
 
 #[derive(Debug, Error)]
-pub enum VariantStructSerializerError {
+pub enum VariantSerializerError {
     #[error("Unknown error when serializing struct:\n{0}")]
     Unknown(String),
-    #[error("VariantSerializer can only be used to serialize structs.")]
+    #[error("VariantStructSerializer can only be used to serialize structs.")]
     ExpectedStruct,
     #[error("{0} cannot be serialized to a Variant.")]
     UnsupportedVariantType(String),
@@ -29,27 +215,19 @@ impl VariantStructSerializer {
     }
 }
 
-impl serde::ser::Error for VariantStructSerializerError {
+impl serde::ser::Error for VariantSerializerError {
     fn custom<T>(msg: T) -> Self
     where
         T: Display,
     {
-        VariantStructSerializerError::Unknown(msg.to_string())
+        VariantSerializerError::Unknown(msg.to_string())
     }
-}
-
-macro_rules! serialize_type_stub {
-    ($signature:ident, $type:ty) => {
-        fn $signature(self, _v: $type) -> Result<Self::Ok, Self::Error> {
-            Err(VariantStructSerializerError::ExpectedStruct)
-        }
-    };
 }
 
 impl Serializer for VariantStructSerializer {
     type Ok = HashMap<String, Variant>;
 
-    type Error = VariantStructSerializerError;
+    type Error = VariantSerializerError;
 
     type SerializeStruct = Self;
 
@@ -67,41 +245,41 @@ impl Serializer for VariantStructSerializer {
 
     // The following is code for a generic Serializer implementation not relevant to this use case
 
-    type SerializeSeq = Impossible<Self::Ok, VariantStructSerializerError>;
-    type SerializeTuple = Impossible<Self::Ok, VariantStructSerializerError>;
-    type SerializeTupleStruct = Impossible<Self::Ok, VariantStructSerializerError>;
-    type SerializeTupleVariant = Impossible<Self::Ok, VariantStructSerializerError>;
-    type SerializeMap = Impossible<Self::Ok, VariantStructSerializerError>;
-    type SerializeStructVariant = Impossible<Self::Ok, VariantStructSerializerError>;
+    type SerializeSeq = Impossible<Self::Ok, VariantSerializerError>;
+    type SerializeTuple = Impossible<Self::Ok, VariantSerializerError>;
+    type SerializeTupleStruct = Impossible<Self::Ok, VariantSerializerError>;
+    type SerializeTupleVariant = Impossible<Self::Ok, VariantSerializerError>;
+    type SerializeMap = Impossible<Self::Ok, VariantSerializerError>;
+    type SerializeStructVariant = Impossible<Self::Ok, VariantSerializerError>;
 
-    serialize_type_stub!(serialize_bool, bool);
-    serialize_type_stub!(serialize_i8, i8);
-    serialize_type_stub!(serialize_i16, i16);
-    serialize_type_stub!(serialize_i32, i32);
-    serialize_type_stub!(serialize_i64, i64);
-    serialize_type_stub!(serialize_u8, u8);
-    serialize_type_stub!(serialize_u16, u16);
-    serialize_type_stub!(serialize_u32, u32);
-    serialize_type_stub!(serialize_u64, u64);
-    serialize_type_stub!(serialize_f32, f32);
-    serialize_type_stub!(serialize_f64, f64);
-    serialize_type_stub!(serialize_char, char);
-    serialize_type_stub!(serialize_str, &str);
-    serialize_type_stub!(serialize_bytes, &[u8]);
+    serialize_struct_err_stub!(serialize_bool, bool);
+    serialize_struct_err_stub!(serialize_i8, i8);
+    serialize_struct_err_stub!(serialize_i16, i16);
+    serialize_struct_err_stub!(serialize_i32, i32);
+    serialize_struct_err_stub!(serialize_i64, i64);
+    serialize_struct_err_stub!(serialize_u8, u8);
+    serialize_struct_err_stub!(serialize_u16, u16);
+    serialize_struct_err_stub!(serialize_u32, u32);
+    serialize_struct_err_stub!(serialize_u64, u64);
+    serialize_struct_err_stub!(serialize_f32, f32);
+    serialize_struct_err_stub!(serialize_f64, f64);
+    serialize_struct_err_stub!(serialize_char, char);
+    serialize_struct_err_stub!(serialize_str, &str);
+    serialize_struct_err_stub!(serialize_bytes, &[u8]);
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        Err(VariantStructSerializerError::ExpectedStruct)
+        Err(VariantSerializerError::ExpectedStruct)
     }
 
     fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
     where
         T: ?Sized + Serialize,
     {
-        Err(VariantStructSerializerError::ExpectedStruct)
+        Err(VariantSerializerError::ExpectedStruct)
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        Err(VariantStructSerializerError::ExpectedStruct)
+        Err(VariantSerializerError::ExpectedStruct)
     }
 
     fn serialize_unit_variant(
@@ -110,7 +288,7 @@ impl Serializer for VariantStructSerializer {
         _variant_index: u32,
         _variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
-        Err(VariantStructSerializerError::ExpectedStruct)
+        Err(VariantSerializerError::ExpectedStruct)
     }
 
     fn serialize_newtype_struct<T>(
@@ -121,7 +299,7 @@ impl Serializer for VariantStructSerializer {
     where
         T: ?Sized + Serialize,
     {
-        Err(VariantStructSerializerError::ExpectedStruct)
+        Err(VariantSerializerError::ExpectedStruct)
     }
 
     fn serialize_newtype_variant<T>(
@@ -134,15 +312,15 @@ impl Serializer for VariantStructSerializer {
     where
         T: ?Sized + Serialize,
     {
-        Err(VariantStructSerializerError::ExpectedStruct)
+        Err(VariantSerializerError::ExpectedStruct)
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        Err(VariantStructSerializerError::ExpectedStruct)
+        Err(VariantSerializerError::ExpectedStruct)
     }
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        Err(VariantStructSerializerError::ExpectedStruct)
+        Err(VariantSerializerError::ExpectedStruct)
     }
 
     fn serialize_tuple_struct(
@@ -150,7 +328,7 @@ impl Serializer for VariantStructSerializer {
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        Err(VariantStructSerializerError::ExpectedStruct)
+        Err(VariantSerializerError::ExpectedStruct)
     }
 
     fn serialize_tuple_variant(
@@ -160,11 +338,11 @@ impl Serializer for VariantStructSerializer {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        Err(VariantStructSerializerError::ExpectedStruct)
+        Err(VariantSerializerError::ExpectedStruct)
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        Err(VariantStructSerializerError::ExpectedStruct)
+        Err(VariantSerializerError::ExpectedStruct)
     }
 
     fn serialize_struct_variant(
@@ -174,61 +352,26 @@ impl Serializer for VariantStructSerializer {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        Err(VariantStructSerializerError::ExpectedStruct)
+        Err(VariantSerializerError::ExpectedStruct)
     }
-}
-
-macro_rules! match_type_unsafe {
-    ($target_type:ty, $value:ident) => {
-        || {
-            if typeid::of::<T>() == typeid::of::<$target_type>() {
-                Some(Variant::from(*unsafe {
-                    std::mem::transmute_copy::<&T, &$target_type>(&$value)
-                }))
-            } else {
-                None
-            }
-        }
-    };
 }
 
 impl SerializeStruct for VariantStructSerializer {
     type Ok = <VariantStructSerializer as Serializer>::Ok;
 
-    type Error = VariantStructSerializerError;
+    type Error = VariantSerializerError;
 
     fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
     where
         T: ?Sized + Serialize,
     {
-        let variant = match_type_unsafe!((), value)()
-            .or_else(match_type_unsafe!(i8, value))
-            .or_else(match_type_unsafe!(i16, value))
-            .or_else(match_type_unsafe!(i32, value))
-            .or_else(match_type_unsafe!(i64, value))
-            .or_else(match_type_unsafe!(f32, value))
-            .or_else(match_type_unsafe!(f64, value))
-            .or_else(match_type_unsafe!(bool, value))
-            .or_else(match_type_unsafe!(u8, value))
-            .or_else(match_type_unsafe!(u16, value))
-            .or_else(match_type_unsafe!(u32, value))
-            .or_else(match_type_unsafe!(u64, value))
-            .or_else(|| {
-                if typeid::of::<T>() == typeid::of::<String>() {
-                    Some(Variant::from(
-                        unsafe { std::mem::transmute_copy::<&T, &String>(&value) }.clone(),
-                    ))
-                } else {
-                    None
-                }
-            });
-
+        let variant = value.serialize(VariantSerializer {});
         match variant {
-            Some(value) => {
+            Ok(value) => {
                 self.variant_map.insert(key.to_string(), value);
                 Ok(())
             }
-            None => Err(VariantStructSerializerError::UnsupportedVariantType(
+            Err(_) => Err(VariantSerializerError::UnsupportedVariantType(
                 type_name::<T>().to_string(),
             )),
         }

--- a/src/ser/variant_ser.rs
+++ b/src/ser/variant_ser.rs
@@ -1,0 +1,315 @@
+use std::{any::type_name, collections::HashMap, fmt::Display};
+
+use crate::Variant;
+use serde::{
+    ser::{Impossible, SerializeStruct},
+    Serialize, Serializer,
+};
+use thiserror::Error;
+
+pub struct VariantStructSerializer {
+    variant_map: HashMap<String, Variant>,
+}
+
+#[derive(Debug, Error)]
+pub enum VariantStructSerializerError {
+    #[error("Unknown error when serializing struct:\n{0}")]
+    Unknown(String),
+    #[error("VariantSerializer can only be used to serialize structs.")]
+    ExpectedStruct,
+    #[error("{0} cannot be serialized to a Variant.")]
+    UnsupportedVariantType(String),
+}
+
+impl VariantStructSerializer {
+    pub fn new() -> Self {
+        Self {
+            variant_map: HashMap::new(),
+        }
+    }
+}
+
+impl serde::ser::Error for VariantStructSerializerError {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: Display,
+    {
+        VariantStructSerializerError::Unknown(msg.to_string())
+    }
+}
+
+macro_rules! serialize_type_stub {
+    ($signature:ident, $type:ty) => {
+        fn $signature(self, _v: $type) -> Result<Self::Ok, Self::Error> {
+            Err(VariantStructSerializerError::ExpectedStruct)
+        }
+    };
+}
+
+impl Serializer for VariantStructSerializer {
+    type Ok = HashMap<String, Variant>;
+
+    type Error = VariantStructSerializerError;
+
+    type SerializeStruct = Self;
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Ok(self)
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Ok(HashMap::new())
+    }
+
+    // The following is code for a generic Serializer implementation not relevant to this use case
+
+    type SerializeSeq = Impossible<Self::Ok, VariantStructSerializerError>;
+    type SerializeTuple = Impossible<Self::Ok, VariantStructSerializerError>;
+    type SerializeTupleStruct = Impossible<Self::Ok, VariantStructSerializerError>;
+    type SerializeTupleVariant = Impossible<Self::Ok, VariantStructSerializerError>;
+    type SerializeMap = Impossible<Self::Ok, VariantStructSerializerError>;
+    type SerializeStructVariant = Impossible<Self::Ok, VariantStructSerializerError>;
+
+    serialize_type_stub!(serialize_bool, bool);
+    serialize_type_stub!(serialize_i8, i8);
+    serialize_type_stub!(serialize_i16, i16);
+    serialize_type_stub!(serialize_i32, i32);
+    serialize_type_stub!(serialize_i64, i64);
+    serialize_type_stub!(serialize_u8, u8);
+    serialize_type_stub!(serialize_u16, u16);
+    serialize_type_stub!(serialize_u32, u32);
+    serialize_type_stub!(serialize_u64, u64);
+    serialize_type_stub!(serialize_f32, f32);
+    serialize_type_stub!(serialize_f64, f64);
+    serialize_type_stub!(serialize_char, char);
+    serialize_type_stub!(serialize_str, &str);
+    serialize_type_stub!(serialize_bytes, &[u8]);
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(VariantStructSerializerError::ExpectedStruct)
+    }
+
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(VariantStructSerializerError::ExpectedStruct)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(VariantStructSerializerError::ExpectedStruct)
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(VariantStructSerializerError::ExpectedStruct)
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(VariantStructSerializerError::ExpectedStruct)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(VariantStructSerializerError::ExpectedStruct)
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(VariantStructSerializerError::ExpectedStruct)
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(VariantStructSerializerError::ExpectedStruct)
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(VariantStructSerializerError::ExpectedStruct)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(VariantStructSerializerError::ExpectedStruct)
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(VariantStructSerializerError::ExpectedStruct)
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(VariantStructSerializerError::ExpectedStruct)
+    }
+}
+
+macro_rules! match_type_unsafe {
+    ($target_type:ty, $value:ident) => {
+        || {
+            if typeid::of::<T>() == typeid::of::<$target_type>() {
+                Some(Variant::from(*unsafe {
+                    std::mem::transmute_copy::<&T, &$target_type>(&$value)
+                }))
+            } else {
+                None
+            }
+        }
+    };
+}
+
+impl SerializeStruct for VariantStructSerializer {
+    type Ok = <VariantStructSerializer as Serializer>::Ok;
+
+    type Error = VariantStructSerializerError;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        let variant = match_type_unsafe!((), value)()
+            .or_else(match_type_unsafe!(i8, value))
+            .or_else(match_type_unsafe!(i16, value))
+            .or_else(match_type_unsafe!(i32, value))
+            .or_else(match_type_unsafe!(i64, value))
+            .or_else(match_type_unsafe!(f32, value))
+            .or_else(match_type_unsafe!(f64, value))
+            .or_else(match_type_unsafe!(bool, value))
+            .or_else(match_type_unsafe!(u8, value))
+            .or_else(match_type_unsafe!(u16, value))
+            .or_else(match_type_unsafe!(u32, value))
+            .or_else(match_type_unsafe!(u64, value))
+            .or_else(|| {
+                if typeid::of::<T>() == typeid::of::<String>() {
+                    Some(Variant::from(
+                        unsafe { std::mem::transmute_copy::<&T, &String>(&value) }.clone(),
+                    ))
+                } else {
+                    None
+                }
+            });
+
+        match variant {
+            Some(value) => {
+                self.variant_map.insert(key.to_string(), value);
+                Ok(())
+            }
+            None => Err(VariantStructSerializerError::UnsupportedVariantType(
+                type_name::<T>().to_string(),
+            )),
+        }
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(self.variant_map)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Serialize)]
+    struct TestStruct {
+        empty: (),
+
+        string: String,
+
+        i1: i8,
+        i2: i16,
+        i4: i32,
+        i8: i64,
+
+        r4: f32,
+        r8: f64,
+
+        bool: bool,
+
+        ui1: u8,
+        ui2: u16,
+        ui4: u32,
+        ui8: u64,
+    }
+
+    #[test]
+    fn it_serialize_struct() {
+        let test_struct = TestStruct {
+            empty: (),
+            string: "Test String".to_string(),
+
+            i1: i8::MAX,
+            i2: i16::MAX,
+            i4: i32::MAX,
+            i8: i64::MAX,
+
+            r4: f32::MAX,
+            r8: f64::MAX,
+
+            bool: false,
+
+            ui1: u8::MAX,
+            ui2: u16::MAX,
+            ui4: u32::MAX,
+            ui8: u64::MAX,
+        };
+        let expected_field_map: HashMap<String, Variant> = [
+            ("empty".to_string(), Variant::Empty),
+            (
+                "string".to_string(),
+                Variant::String("Test String".to_string()),
+            ),
+            ("i1".to_string(), Variant::I1(i8::MAX)),
+            ("i2".to_string(), Variant::I2(i16::MAX)),
+            ("i4".to_string(), Variant::I4(i32::MAX)),
+            ("i8".to_string(), Variant::I8(i64::MAX)),
+            ("r4".to_string(), Variant::R4(f32::MAX)),
+            ("r8".to_string(), Variant::R8(f64::MAX)),
+            ("bool".to_string(), Variant::Bool(false)),
+            ("ui1".to_string(), Variant::UI1(u8::MAX)),
+            ("ui2".to_string(), Variant::UI2(u16::MAX)),
+            ("ui4".to_string(), Variant::UI4(u32::MAX)),
+            ("ui8".to_string(), Variant::UI8(u64::MAX)),
+        ]
+        .into_iter()
+        .collect();
+
+        let variant_serializer = VariantStructSerializer::new();
+        let field_map = test_struct.serialize(variant_serializer).unwrap();
+
+        assert_eq!(field_map, expected_field_map);
+    }
+}

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -8,7 +8,7 @@ use windows::Win32::Foundation::{VARIANT_BOOL, VARIANT_FALSE, VARIANT_TRUE};
 use windows::Win32::System::Variant::*;
 use windows::Win32::System::Wmi::{self, IWbemClassObject, CIMTYPE_ENUMERATION};
 
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Debug, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum Variant {
     Empty,
@@ -385,7 +385,7 @@ impl TryFrom<Variant> for () {
 /// Used to retrive [`IWbemClassObject`][winapi::um::Wmi::IWbemClassObject]
 ///
 #[repr(transparent)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct IUnknownWrapper {
     inner: IUnknown,
 }
@@ -628,10 +628,7 @@ mod tests {
     fn it_bidirectional_string_convert() {
         let string = "Test String".to_string();
         let variant = Variant::from(string.clone());
-        assert_eq!(
-            <Variant as TryInto<String>>::try_into(variant).unwrap(),
-            string
-        );
+        assert_eq!(variant.try_into().ok(), Some(string.clone()));
 
         let variant = Variant::from(string.clone());
         let ms_variant = VARIANT::try_from(variant).unwrap();
@@ -642,7 +639,7 @@ mod tests {
     #[test]
     fn it_bidirectional_empty_convert() {
         let variant = Variant::from(());
-        assert_eq!(<Variant as TryInto<()>>::try_into(variant).unwrap(), ());
+        assert_eq!(variant.try_into().ok(), Some(()));
 
         let variant = Variant::from(());
         let ms_variant = VARIANT::try_from(variant).unwrap();
@@ -654,7 +651,7 @@ mod tests {
     fn it_bidirectional_r8_convert() {
         let num = 0.123456789;
         let variant = Variant::from(num);
-        assert_eq!(<Variant as TryInto<f64>>::try_into(variant).unwrap(), num);
+        assert_eq!(variant.try_into().ok(), Some(num));
 
         let variant = Variant::from(num);
         let ms_variant = VARIANT::try_from(variant).unwrap();

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -328,6 +328,7 @@ macro_rules! impl_try_from_variant {
     };
 }
 
+/// Infallible conversion from a Rust type into a Variant wrapper for that type
 macro_rules! impl_wrap_type {
     ($target_type:ty, $variant_type:ident) => {
         impl From<$target_type> for Variant {
@@ -338,6 +339,7 @@ macro_rules! impl_wrap_type {
     };
 }
 
+/// Add conversions from a Rust type to its Variant form and vice versa
 macro_rules! bidirectional_variant_convert {
     ($target_type:ty, $variant_type:ident) => {
         impl_try_from_variant!($target_type, $variant_type);


### PR DESCRIPTION
WMIConnection now supports calling both instance and class methods with an idiomatic Rust API that automatically serializes and deserializes to/from Rust structs.

The WMI method calling code is based on the example from the windows-rs crate: https://github.com/microsoft/windows-rs/pull/2794

Comments and documentation are still WIP, ~~and there is an awful hack in struct serialization that I'd like to get rid of,~~ which is why this PR is currently a draft.

Closes #18
Closes #58