### PR TITLE
Added `put_property` method for `IWbemClassWrapper`

### DIFF
--- a/src/method.rs
+++ b/src/method.rs
@@ -300,4 +300,34 @@ mod tests {
 
         assert!(wmi_con.raw_query::<Win32_Process>(&query).unwrap().len() == 0);
     }
+
+    #[test]
+    fn it_exec_with_u8_arrays() {
+        let wmi_con = wmi_con();
+
+        #[derive(Deserialize)]
+        struct StdRegProv;
+
+        #[derive(Serialize)]
+        struct GetBinaryValueParams {
+            sSubKeyName: String,
+            sValueName: String,
+        }
+
+        #[derive(Deserialize)]
+        struct GetBinaryValueOut {
+            uValue: Vec<u8>,
+        }
+
+        let in_params = GetBinaryValueParams {
+            sSubKeyName: r#"SYSTEM\CurrentControlSet\Control\Windows"#.to_string(),
+            sValueName: "FullProcessInformationSID".to_string(),
+        };
+
+        let value: GetBinaryValueOut = wmi_con
+            .exec_class_method::<StdRegProv, _, _>("GetBinaryValue", in_params)
+            .unwrap();
+
+        assert!(value.uValue.len() > 0, "Expected to get a non-empty value");
+    }
 }

--- a/src/result_enumerator.rs
+++ b/src/result_enumerator.rs
@@ -75,6 +75,24 @@ impl IWbemClassWrapper {
         }
     }
 
+    pub fn put_property(&self, property_name: &str, value: impl Into<Variant>) -> WMIResult<()> {
+        let name_prop = HSTRING::from(property_name);
+
+        let value = value.into();
+        let vt_prop: VARIANT = value.try_into()?;
+
+        // "In every other case, vtType must be 0 (zero)"
+        // See more at https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemclassobject-put
+        let cim_type = 0;
+
+        unsafe {
+            self.inner
+                .Put(PCWSTR::from_raw(name_prop.as_ptr()), 0, &vt_prop, cim_type)?;
+        }
+
+        Ok(())
+    }
+
     pub fn path(&self) -> WMIResult<String> {
         self.get_property("__Path").and_then(Variant::try_into)
     }

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -367,6 +367,12 @@ impl From<()> for Variant {
     }
 }
 
+impl From<&str> for Variant {
+    fn from(value: &str) -> Self {
+        Variant::String(value.to_string())
+    }
+}
+
 impl TryFrom<Variant> for () {
     type Error = WMIError;
 


### PR DESCRIPTION
Allows for setting properties using the `Put` WMI method.