### PR TITLE
Split method-calling logic between `IWbemClassWrapper` and `WMIConnection`, rename lower-level functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wmi"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Ohad Ravid <ohad.rv@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/async_query.rs
+++ b/src/async_query.rs
@@ -19,7 +19,7 @@ impl WMIConnection {
     /// method. Provides safety checks, and returns results
     /// as a Stream instead of the original Sink.
     ///
-    pub fn exec_query_async_native_wrapper(
+    pub fn exec_query_async(
         &self,
         query: impl AsRef<str>,
     ) -> WMIResult<impl Stream<Item = WMIResult<IWbemClassWrapper>>> {
@@ -77,7 +77,7 @@ impl WMIConnection {
     where
         T: de::DeserializeOwned,
     {
-        self.exec_query_async_native_wrapper(query)?
+        self.exec_query_async(query)?
             .map(|item| match item {
                 Ok(wbem_class_obj) => wbem_class_obj.into_desr(),
                 Err(e) => Err(e),
@@ -147,7 +147,7 @@ mod tests {
         let wmi_con = wmi_con();
 
         let result = wmi_con
-            .exec_query_async_native_wrapper("SELECT OSArchitecture FROM Win32_OperatingSystem")
+            .exec_query_async("SELECT OSArchitecture FROM Win32_OperatingSystem")
             .unwrap()
             .collect::<Vec<_>>()
             .await;
@@ -160,7 +160,7 @@ mod tests {
         let wmi_con = wmi_con();
 
         let result = wmi_con
-            .exec_query_async_native_wrapper("SELECT OSArchitecture FROM Win32_OperatingSystem")
+            .exec_query_async("SELECT OSArchitecture FROM Win32_OperatingSystem")
             .unwrap()
             .collect::<Vec<_>>()
             .await;
@@ -173,7 +173,7 @@ mod tests {
         let wmi_con = wmi_con();
 
         let result = wmi_con
-            .exec_query_async_native_wrapper("invalid query")
+            .exec_query_async("invalid query")
             .unwrap()
             .collect::<Vec<_>>()
             .await;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -43,7 +43,7 @@ pub struct COMLibrary {
 /// Initialize COM.
 ///
 /// `CoUninitialize` will NOT be called when dropped.
-/// See: https://github.com/microsoft/windows-rs/issues/1169#issuecomment-926877227
+/// See: <https://github.com/microsoft/windows-rs/issues/1169#issuecomment-926877227>.
 ///
 impl COMLibrary {
     /// `CoInitialize`s the COM library for use by the calling thread.
@@ -123,6 +123,8 @@ impl COMLibrary {
 /// ```
 fn _test_com_lib_not_send(_s: impl Send) {}
 
+/// A connection to the local WMI provider.
+///
 #[derive(Clone, Debug)]
 pub struct WMIConnection {
     _com_con: COMLibrary,
@@ -130,10 +132,6 @@ pub struct WMIConnection {
     pub(crate) ctx: WMIContext,
 }
 
-/// A connection to the local WMI provider, which provides querying capabilities.
-///
-/// Currently does not support remote providers (e.g connecting to other computers).
-///
 impl WMIConnection {
     /// Creates a connection with a default `CIMV2` namespace path.
     pub fn new(com_lib: COMLibrary) -> WMIResult<Self> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -27,6 +27,7 @@ impl From<ContextValueType> for VARIANT {
     }
 }
 
+/// Provides access to WMI's context, available via [`WMIConnection::ctx`].
 #[derive(Clone, Debug)]
 pub struct WMIContext(pub(crate) IWbemContext);
 
@@ -44,7 +45,7 @@ impl WMIContext {
 
     /// Sets the specified named context value for use in providing additional context information to queries.
     ///
-    /// Note the context values will persist across subsequent queries until [`WMIConnection::delete_all`] is called.
+    /// Note the context values will persist across subsequent queries until [`WMIContext::delete_all`] is called.
     pub fn set_value(&mut self, key: &str, value: impl Into<ContextValueType>) -> WMIResult<()> {
         let value = value.into();
         unsafe { self.0.SetValue(&BSTR::from(key), 0, &value.into())? };

--- a/src/de/wbem_class_de.rs
+++ b/src/de/wbem_class_de.rs
@@ -267,7 +267,7 @@ mod tests {
         }
 
         let enumerator = wmi_con
-            .exec_query_native_wrapper("SELECT * FROM Win32_OperatingSystem")
+            .exec_query("SELECT * FROM Win32_OperatingSystem")
             .unwrap();
 
         for res in enumerator {
@@ -292,7 +292,7 @@ mod tests {
         let wmi_con = wmi_con();
 
         let enumerator = wmi_con
-            .exec_query_native_wrapper("SELECT * FROM Win32_OperatingSystem")
+            .exec_query("SELECT * FROM Win32_OperatingSystem")
             .unwrap();
 
         for res in enumerator {
@@ -323,7 +323,7 @@ mod tests {
         let wmi_con = wmi_con();
 
         let enumerator = wmi_con
-            .exec_query_native_wrapper("SELECT Caption FROM Win32_OperatingSystem")
+            .exec_query("SELECT Caption FROM Win32_OperatingSystem")
             .unwrap();
 
         for res in enumerator {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@
 //!
 //! Event listening - [`WMIConnection::notification`] and [`WMIConnection::filtered_notification`].
 //!
-//! Method calling - [`WMIConnection::with_class`], [`WMIConnection::with_class_by_name`], [`WMIClass::exec_class_method`] and [`WMIClass::exec_instance_method`].
+//! Method calling - [`WMIConnection::exec_class_method`] and [`WMIConnection::exec_instance_method`].
 //!
 //! Most of these have `async` versions as well.
 //!
@@ -217,7 +217,7 @@
 //!
 //! The crate also offers support for executing WMI methods on classes and instances.
 //!
-//! See [`WMIClass::exec_class_method`], [`WMIClass::exec_instance_method`] and [`WMIConnection::exec_method`]
+//! See [`WMIConnection::exec_class_method`], [`WMIConnection::exec_instance_method`] and [`WMIConnection::exec_method`]
 //! for detailed examples.
 //!
 //! # Internals
@@ -312,7 +312,6 @@ pub use datetime_time::WMIOffsetDateTime;
 
 pub use context::{ContextValueType, WMIContext};
 pub use duration::WMIDuration;
-pub use method::WMIClass;
 pub use query::{build_notification_query, build_query, quote_and_escape_wql_str, FilterValue};
 pub use result_enumerator::IWbemClassWrapper;
 pub use utils::{WMIError, WMIResult};

--- a/src/method.rs
+++ b/src/method.rs
@@ -77,7 +77,7 @@ impl WMIConnection {
     /// ```edition2021
     /// # use serde::{Deserialize, Serialize};
     /// # use wmi::{COMLibrary, Variant, WMIConnection, WMIResult};
-    /// #[derive(Serialize, Deserialize)]
+    /// #[derive(Serialize)]
     /// # #[allow(non_snake_case)]
     /// struct CreateInput {
     ///     CommandLine: String

--- a/src/query_sink.rs
+++ b/src/query_sink.rs
@@ -222,10 +222,10 @@ mod tests {
         let mut stream = AsyncQueryResultStream::new(stream, con.clone(), p_sink.clone());
 
         let raw_os = con
-            .get_raw_by_path(r#"\\.\root\cimv2:Win32_OperatingSystem=@"#)
+            .get_object(r#"\\.\root\cimv2:Win32_OperatingSystem=@"#)
             .unwrap();
         let raw_os2 = con
-            .get_raw_by_path(r#"\\.\root\cimv2:Win32_OperatingSystem=@"#)
+            .get_object(r#"\\.\root\cimv2:Win32_OperatingSystem=@"#)
             .unwrap();
 
         // tests on ref count before Indicate call

--- a/src/ser/variant_ser.rs
+++ b/src/ser/variant_ser.rs
@@ -1,21 +1,13 @@
 //! This module implements a custom serializer type, [`VariantStructSerializer`],
 //! to serialize a Rust struct into a HashMap mapping field name strings to [`Variant`] values
-use std::{any::type_name, collections::HashMap, fmt::Display};
+use std::{any::type_name, fmt::Display};
 
-use crate::Variant;
+use crate::{result_enumerator::IWbemClassWrapper, Variant, WMIConnection, WMIError};
 use serde::{
     ser::{Impossible, SerializeStruct},
     Serialize, Serializer,
 };
 use thiserror::Error;
-
-macro_rules! serialize_struct_err_stub {
-    ($signature:ident, $type:ty) => {
-        fn $signature(self, _v: $type) -> Result<Self::Ok, Self::Error> {
-            Err(VariantSerializerError::ExpectedStruct)
-        }
-    };
-}
 
 macro_rules! serialize_variant_err_stub {
     ($signature:ident, $type:ty) => {
@@ -35,7 +27,10 @@ macro_rules! serialize_variant {
     };
 }
 
-struct VariantSerializer {}
+pub(crate) struct VariantSerializer {
+    pub(crate) wmi: WMIConnection,
+    pub(crate) class: Option<String>,
+}
 
 impl Serializer for VariantSerializer {
     type Ok = Variant;
@@ -46,7 +41,7 @@ impl Serializer for VariantSerializer {
     type SerializeTupleStruct = Impossible<Self::Ok, Self::Error>;
     type SerializeTupleVariant = Impossible<Self::Ok, Self::Error>;
     type SerializeMap = Impossible<Self::Ok, Self::Error>;
-    type SerializeStruct = Impossible<Self::Ok, Self::Error>;
+    type SerializeStruct = VariantInstanceSerializer;
     type SerializeStructVariant = Impossible<Self::Ok, Self::Error>;
 
     serialize_variant!(serialize_bool, bool);
@@ -82,8 +77,10 @@ impl Serializer for VariantSerializer {
         value.serialize(self)
     }
 
-    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
-        self.serialize_unit()
+    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+        let ser = self.serialize_struct(name, 0)?;
+
+        ser.end()
     }
 
     fn serialize_newtype_struct<T>(
@@ -171,9 +168,19 @@ impl Serializer for VariantSerializer {
         name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        Err(VariantSerializerError::UnsupportedVariantType(
-            name.to_string(),
-        ))
+        // See https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemclassobject-getmethod
+        // GetMethod can only be called on a class definition, so we retrieve that before retrieving a specific object
+        let instance = match self.class.as_deref() {
+            Some(class) => self.wmi.get_object(class)?.get_method(name)?,
+            None => Some(self.wmi.get_object(name)?),
+        };
+
+        let ser = VariantInstanceSerializer {
+            wmi: self.wmi,
+            instance,
+        };
+
+        Ok(ser)
     }
 
     fn serialize_struct_variant(
@@ -189,52 +196,16 @@ impl Serializer for VariantSerializer {
     }
 }
 
-/// Serializes a struct to a HashMap of key-value pairs, with the key being the field name, and the value being the field value wrapped in a [`Variant`].
-///
-/// VariantStructSerializer only supports serializing fields with basic Rust data types: `i32`, `()`, etc., as well as any of the former in a newtype.
-///
-/// ```edition2021
-/// use serde::Serialize;
-/// use wmi::ser::variant_ser::VariantStructSerializer;
-///
-/// #[derive(Serialize)]
-/// struct TestStruct {
-///     number: f32,
-///     text: String
-/// }
-///
-/// let test_struct = TestStruct {
-///     number: 0.6,
-///     text: "foobar".to_string()
-/// };
-///
-/// let fields = test_struct.serialize(VariantStructSerializer::new()).unwrap();
-///
-/// for (field_name, field_value) in fields {
-///     println!("{field_name}: {field_value:?}");
-/// }
-/// ```
-#[derive(Default)]
-pub struct VariantStructSerializer {
-    variant_map: HashMap<String, Variant>,
-}
-
 #[derive(Debug, Error)]
 pub enum VariantSerializerError {
-    #[error("Unknown error when serializing struct:\n{0}")]
+    #[error("Unknown error while serializing struct:\n{0}")]
     Unknown(String),
     #[error("VariantStructSerializer can only be used to serialize structs.")]
     ExpectedStruct,
     #[error("{0} cannot be serialized to a Variant.")]
     UnsupportedVariantType(String),
-}
-
-impl VariantStructSerializer {
-    pub fn new() -> Self {
-        Self {
-            variant_map: HashMap::new(),
-        }
-    }
+    #[error("WMI error while serializing struct: \n {0}")]
+    WMIError(#[from] WMIError),
 }
 
 impl serde::ser::Error for VariantSerializerError {
@@ -246,140 +217,13 @@ impl serde::ser::Error for VariantSerializerError {
     }
 }
 
-impl Serializer for VariantStructSerializer {
-    type Ok = HashMap<String, Variant>;
-
-    type Error = VariantSerializerError;
-
-    type SerializeStruct = Self;
-
-    fn serialize_struct(
-        self,
-        _name: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeStruct, Self::Error> {
-        Ok(self)
-    }
-
-    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
-        self.serialize_unit()
-    }
-
-    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        Ok(HashMap::new())
-    }
-
-    fn serialize_newtype_struct<T>(
-        self,
-        _name: &'static str,
-        value: &T,
-    ) -> Result<Self::Ok, Self::Error>
-    where
-        T: ?Sized + Serialize,
-    {
-        value.serialize(self)
-    }
-
-    // The following is code for a generic Serializer implementation not relevant to this use case
-
-    type SerializeSeq = Impossible<Self::Ok, VariantSerializerError>;
-    type SerializeTuple = Impossible<Self::Ok, VariantSerializerError>;
-    type SerializeTupleStruct = Impossible<Self::Ok, VariantSerializerError>;
-    type SerializeTupleVariant = Impossible<Self::Ok, VariantSerializerError>;
-    type SerializeMap = Impossible<Self::Ok, VariantSerializerError>;
-    type SerializeStructVariant = Impossible<Self::Ok, VariantSerializerError>;
-
-    serialize_struct_err_stub!(serialize_bool, bool);
-    serialize_struct_err_stub!(serialize_i8, i8);
-    serialize_struct_err_stub!(serialize_i16, i16);
-    serialize_struct_err_stub!(serialize_i32, i32);
-    serialize_struct_err_stub!(serialize_i64, i64);
-    serialize_struct_err_stub!(serialize_u8, u8);
-    serialize_struct_err_stub!(serialize_u16, u16);
-    serialize_struct_err_stub!(serialize_u32, u32);
-    serialize_struct_err_stub!(serialize_u64, u64);
-    serialize_struct_err_stub!(serialize_f32, f32);
-    serialize_struct_err_stub!(serialize_f64, f64);
-    serialize_struct_err_stub!(serialize_char, char);
-    serialize_struct_err_stub!(serialize_str, &str);
-    serialize_struct_err_stub!(serialize_bytes, &[u8]);
-
-    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        Err(VariantSerializerError::ExpectedStruct)
-    }
-
-    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
-    where
-        T: ?Sized + Serialize,
-    {
-        Err(VariantSerializerError::ExpectedStruct)
-    }
-
-    fn serialize_unit_variant(
-        self,
-        _name: &'static str,
-        _variant_index: u32,
-        _variant: &'static str,
-    ) -> Result<Self::Ok, Self::Error> {
-        Err(VariantSerializerError::ExpectedStruct)
-    }
-
-    fn serialize_newtype_variant<T>(
-        self,
-        _name: &'static str,
-        _variant_index: u32,
-        _variant: &'static str,
-        _value: &T,
-    ) -> Result<Self::Ok, Self::Error>
-    where
-        T: ?Sized + Serialize,
-    {
-        Err(VariantSerializerError::ExpectedStruct)
-    }
-
-    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        Err(VariantSerializerError::ExpectedStruct)
-    }
-
-    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        Err(VariantSerializerError::ExpectedStruct)
-    }
-
-    fn serialize_tuple_struct(
-        self,
-        _name: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        Err(VariantSerializerError::ExpectedStruct)
-    }
-
-    fn serialize_tuple_variant(
-        self,
-        _name: &'static str,
-        _variant_index: u32,
-        _variant: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        Err(VariantSerializerError::ExpectedStruct)
-    }
-
-    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        Err(VariantSerializerError::ExpectedStruct)
-    }
-
-    fn serialize_struct_variant(
-        self,
-        _name: &'static str,
-        _variant_index: u32,
-        _variant: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        Err(VariantSerializerError::ExpectedStruct)
-    }
+pub(crate) struct VariantInstanceSerializer {
+    instance: Option<IWbemClassWrapper>,
+    wmi: WMIConnection,
 }
 
-impl SerializeStruct for VariantStructSerializer {
-    type Ok = <VariantStructSerializer as Serializer>::Ok;
+impl SerializeStruct for VariantInstanceSerializer {
+    type Ok = Variant;
 
     type Error = VariantSerializerError;
 
@@ -387,10 +231,19 @@ impl SerializeStruct for VariantStructSerializer {
     where
         T: ?Sized + Serialize,
     {
-        let variant = value.serialize(VariantSerializer {});
+        let variant = value.serialize(VariantSerializer {
+            wmi: self.wmi.clone(),
+            class: None,
+        });
+
+        let instance = self
+            .instance
+            .as_ref()
+            .ok_or(VariantSerializerError::ExpectedStruct)?;
+
         match variant {
             Ok(value) => {
-                self.variant_map.insert(key.to_string(), value);
+                instance.put_property(key, value).unwrap();
                 Ok(())
             }
             Err(_) => Err(VariantSerializerError::UnsupportedVariantType(
@@ -400,148 +253,153 @@ impl SerializeStruct for VariantStructSerializer {
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        Ok(self.variant_map)
+        match self.instance {
+            Some(instance) => Ok(Variant::Object(instance)),
+            None => Ok(Variant::Empty),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[derive(Serialize)]
-    struct TestStruct {
-        empty: (),
-
-        string: String,
-
-        i1: i8,
-        i2: i16,
-        i4: i32,
-        i8: i64,
-
-        r4: f32,
-        r8: f64,
-
-        bool: bool,
-
-        ui1: u8,
-        ui2: u16,
-        ui4: u32,
-        ui8: u64,
-    }
+    use crate::tests::fixtures::wmi_con;
+    use serde::{Deserialize, Serialize};
 
     #[test]
-    fn it_serialize_struct() {
-        let test_struct = TestStruct {
-            empty: (),
-            string: "Test String".to_string(),
+    fn it_serialize_instance() {
+        let wmi_con = wmi_con();
 
-            i1: i8::MAX,
-            i2: i16::MAX,
-            i4: i32::MAX,
-            i8: i64::MAX,
+        #[derive(Deserialize)]
+        struct StdRegProv;
 
-            r4: f32::MAX,
-            r8: f64::MAX,
-
-            bool: false,
-
-            ui1: u8::MAX,
-            ui2: u16::MAX,
-            ui4: u32::MAX,
-            ui8: u64::MAX,
-        };
-        let expected_field_map: HashMap<String, Variant> = [
-            ("empty".to_string(), Variant::Empty),
-            (
-                "string".to_string(),
-                Variant::String("Test String".to_string()),
-            ),
-            ("i1".to_string(), Variant::I1(i8::MAX)),
-            ("i2".to_string(), Variant::I2(i16::MAX)),
-            ("i4".to_string(), Variant::I4(i32::MAX)),
-            ("i8".to_string(), Variant::I8(i64::MAX)),
-            ("r4".to_string(), Variant::R4(f32::MAX)),
-            ("r8".to_string(), Variant::R8(f64::MAX)),
-            ("bool".to_string(), Variant::Bool(false)),
-            ("ui1".to_string(), Variant::UI1(u8::MAX)),
-            ("ui2".to_string(), Variant::UI2(u16::MAX)),
-            ("ui4".to_string(), Variant::UI4(u32::MAX)),
-            ("ui8".to_string(), Variant::UI8(u64::MAX)),
-        ]
-        .into_iter()
-        .collect();
-
-        let variant_serializer = VariantStructSerializer::new();
-        let field_map = test_struct.serialize(variant_serializer).unwrap();
-
-        assert_eq!(field_map, expected_field_map);
-    }
-
-    #[derive(Serialize)]
-    struct NewtypeTest(u32);
-    #[derive(Serialize)]
-    struct NewtypeTestWrapper {
-        newtype: NewtypeTest,
-    }
-    #[test]
-    fn it_serialize_newtype() {
-        let test_struct = NewtypeTestWrapper {
-            newtype: NewtypeTest(17),
+        #[derive(Serialize)]
+        struct GetBinaryValue {
+            sSubKeyName: String,
+            sValueName: String,
+        }
+        let in_params = GetBinaryValue {
+            sSubKeyName: r#"SYSTEM\CurrentControlSet\Control\Windows"#.to_string(),
+            sValueName: "FullProcessInformationSID".to_string(),
         };
 
-        let expected_field_map: HashMap<String, Variant> =
-            [("newtype".to_string(), Variant::UI4(17))]
-                .into_iter()
-                .collect();
-
-        let field_map = test_struct
-            .serialize(VariantStructSerializer::new())
+        let instance_from_ser = in_params
+            .serialize(VariantSerializer {
+                wmi: wmi_con.clone(),
+                class: "StdRegProv".to_string().into(),
+            })
             .unwrap();
 
-        assert_eq!(field_map, expected_field_map);
-    }
-
-    #[derive(Serialize)]
-    struct UnitTest;
-
-    #[test]
-    fn it_serialize_unit() {
-        let expected_field_map = HashMap::new();
-        let field_map = UnitTest {}
-            .serialize(VariantStructSerializer::new())
-            .unwrap();
-
-        assert_eq!(field_map, expected_field_map);
-    }
-
-    #[derive(Serialize)]
-    #[allow(dead_code)]
-    enum EnumTest {
-        NTFS,
-        FAT32,
-        ReFS,
-    }
-
-    #[derive(Serialize)]
-    struct EnumStructTest {
-        enum_test: EnumTest,
-    }
-
-    #[test]
-    fn it_serialize_enum() {
-        let test_enum_struct = EnumStructTest {
-            enum_test: EnumTest::NTFS,
+        let instance_from_ser = match instance_from_ser {
+            Variant::Object(instance_from_ser) => instance_from_ser,
+            _ => panic!("Unexpected value {:?}", instance_from_ser),
         };
 
-        let expected_field_map = [("enum_test".to_string(), Variant::from("NTFS".to_string()))]
-            .into_iter()
-            .collect();
-
-        let field_map = test_enum_struct
-            .serialize(VariantStructSerializer::new())
+        let expected_instance = wmi_con
+            .get_object("StdRegProv")
+            .unwrap()
+            .get_method("GetBinaryValue")
+            .unwrap()
+            .unwrap()
+            .spawn_instance()
             .unwrap();
 
-        assert_eq!(field_map, expected_field_map);
+        assert_eq!(
+            instance_from_ser.class().unwrap(),
+            expected_instance.class().unwrap()
+        );
+
+        assert_eq!(
+            instance_from_ser.get_property("sSubKeyName").unwrap(),
+            Variant::String(in_params.sSubKeyName)
+        );
+    }
+
+    #[test]
+    fn it_serialize_instance_nested() {
+        let wmi_con = wmi_con();
+
+        #[derive(Debug, Serialize, Default)]
+        pub struct Win32_ProcessStartup {
+            pub Title: String,
+        }
+
+        #[derive(Deserialize)]
+        struct Win32_Process;
+
+        #[derive(Serialize)]
+        struct Create {
+            CommandLine: String,
+            ProcessStartupInformation: Win32_ProcessStartup,
+        }
+
+        // Verify that `Win32_ProcessStartup` can be serialized.
+        let startup_info = Win32_ProcessStartup {
+            Title: "Pong".to_string(),
+        };
+
+        let startup_info_instance = startup_info
+            .serialize(VariantSerializer {
+                wmi: wmi_con.clone(),
+                class: None,
+            })
+            .unwrap();
+
+        let startup_info_instance = match startup_info_instance {
+            Variant::Object(startup_info_instance) => startup_info_instance,
+            _ => panic!("Unexpected value {:?}", startup_info_instance),
+        };
+
+        assert_eq!(
+            startup_info_instance.class().unwrap(),
+            "Win32_ProcessStartup"
+        );
+        assert_eq!(
+            startup_info_instance.get_property("Title").unwrap(),
+            Variant::String(startup_info.Title.clone())
+        );
+
+        let create_params = Create {
+            CommandLine: r#"ping -n 3 127.0.0.1"#.to_string(),
+            ProcessStartupInformation: startup_info,
+        };
+
+        let instance_from_ser = create_params
+            .serialize(VariantSerializer {
+                wmi: wmi_con.clone(),
+                class: "Win32_Process".to_string().into(),
+            })
+            .unwrap();
+
+        let instance_from_ser = match instance_from_ser {
+            Variant::Object(instance_from_ser) => instance_from_ser,
+            _ => panic!("Unexpected value {:?}", instance_from_ser),
+        };
+
+        let expected_instance = wmi_con
+            .get_object("Win32_Process")
+            .unwrap()
+            .get_method("Create")
+            .unwrap()
+            .unwrap()
+            .spawn_instance()
+            .unwrap();
+
+        assert_eq!(
+            instance_from_ser.class().unwrap(),
+            expected_instance.class().unwrap()
+        );
+
+        assert_eq!(
+            instance_from_ser.get_property("CommandLine").unwrap(),
+            Variant::String(create_params.CommandLine)
+        );
+
+        assert!(matches!(
+            instance_from_ser
+                .get_property("ProcessStartupInformation")
+                .unwrap(),
+            Variant::Object(_)
+        ));
     }
 }

--- a/src/ser/variant_ser.rs
+++ b/src/ser/variant_ser.rs
@@ -66,15 +66,17 @@ impl Serializer for VariantSerializer {
 
     fn serialize_newtype_variant<T>(
         self,
-        _name: &'static str,
+        name: &'static str,
         _variant_index: u32,
-        _variant: &'static str,
-        value: &T,
+        variant: &'static str,
+        _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
         T: ?Sized + Serialize,
     {
-        value.serialize(self)
+        Err(VariantSerializerError::UnsupportedVariantType(format!(
+            "{variant}::{name}"
+        )))
     }
 
     fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
@@ -243,7 +245,7 @@ impl SerializeStruct for VariantInstanceSerializer {
 
         match variant {
             Ok(value) => {
-                instance.put_property(key, value).unwrap();
+                instance.put_property(key, value)?;
                 Ok(())
             }
             Err(_) => Err(VariantSerializerError::UnsupportedVariantType(

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -293,6 +293,7 @@ impl TryFrom<Variant> for VARIANT {
             Variant::UI4(uint32) => Ok(VARIANT::from(uint32)),
             Variant::UI8(uint64) => Ok(VARIANT::from(uint64)),
             Variant::Object(instance) => Ok(VARIANT::from(IUnknown::from(instance.inner))),
+            Variant::Unknown(unknown) => Ok(VARIANT::from(unknown.inner)),
 
             // windows-rs' VARIANT does not support creating these types of VARIANT at present
             Variant::Null => Err(WMIError::ConvertVariantError(
@@ -300,9 +301,6 @@ impl TryFrom<Variant> for VARIANT {
             )),
             Variant::Array(_) => Err(WMIError::ConvertVariantError(
                 "Cannot convert Variant::Array to a Windows VARIANT".to_string(),
-            )),
-            Variant::Unknown(_) => Err(WMIError::ConvertVariantError(
-                "Cannot convert Variant::Unknown to a Windows VARIANT".to_string(),
             )),
         }
     }

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -292,6 +292,7 @@ impl TryFrom<Variant> for VARIANT {
             Variant::UI2(uint16) => Ok(VARIANT::from(uint16)),
             Variant::UI4(uint32) => Ok(VARIANT::from(uint32)),
             Variant::UI8(uint64) => Ok(VARIANT::from(uint64)),
+            Variant::Object(instance) => Ok(VARIANT::from(IUnknown::from(instance.inner))),
 
             // windows-rs' VARIANT does not support creating these types of VARIANT at present
             Variant::Null => Err(WMIError::ConvertVariantError(
@@ -302,9 +303,6 @@ impl TryFrom<Variant> for VARIANT {
             )),
             Variant::Unknown(_) => Err(WMIError::ConvertVariantError(
                 "Cannot convert Variant::Unknown to a Windows VARIANT".to_string(),
-            )),
-            Variant::Object(_) => Err(WMIError::ConvertVariantError(
-                "Cannot convert Variant::Object to a Windows VARIANT".to_string(),
             )),
         }
     }

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -358,6 +358,7 @@ bidirectional_variant_convert!(u64, UI8);
 bidirectional_variant_convert!(f32, R4);
 bidirectional_variant_convert!(f64, R8);
 bidirectional_variant_convert!(bool, Bool);
+bidirectional_variant_convert!(IWbemClassWrapper, Object);
 
 impl From<()> for Variant {
     fn from(_value: ()) -> Self {


### PR DESCRIPTION
Add support for "nested" structures in method input parameters (see the updated `it_exec_methods` test), and expose a lot of the lower-level functionality directly in `IWbemClassWrapper`.

This PR changes the API for calling methods slightly: 

Before:
```rust
let output: CreateOutput = wmi_con.exec_class_method::<Win32_Process, _, _>("Create", input)?;
let output: PrinterOutput = wmi_con.exec_instance_method::<Win32_Printer, _, _>("Pause", &printer.__Path, ())?;
```

After:
```rust
// Only the Class and Out generics are named.
let output: CreateOutput = wmi_con.exec_class_method::<Win32_Process, _>("Create", input)?;
let output: PrinterOutput = wmi_con.exec_instance_method::<Win32_Printer, _>(&printer.__Path, "Pause", ())?;
```

Other breaking changes:
1. Rename lower-level (`_native`) methods to match the original names (`exec_method_native_wrapper` -> `exec_method`, `exec_query_native_wrapper` -> `exec_query`, etc.)
2. Only expose as `pub` the needed structures and functions.