### PR TITLE
Support Array Serialization

### DIFF
--- a/src/method.rs
+++ b/src/method.rs
@@ -345,10 +345,10 @@ mod tests {
 
         #[derive(Deserialize)]
         struct SetBinaryValueOut {
-            ReturnValue: u32
+            ReturnValue: u32,
         }
 
-        let test_value_name =  format!("{}.test", get_binary_value_params.sValueName);
+        let test_value_name = format!("{}.test", get_binary_value_params.sValueName);
         let test_value = vec![0, 1, 2, 3];
 
         let set_binary_value_params = SetBinaryValue {
@@ -356,7 +356,7 @@ mod tests {
             sValueName: test_value_name,
             uValue: test_value,
         };
-        
+
         let value: SetBinaryValueOut = wmi_con
             .exec_class_method::<StdRegProv, _>("SetBinaryValue", &set_binary_value_params)
             .unwrap();

--- a/src/safearray.rs
+++ b/src/safearray.rs
@@ -3,7 +3,7 @@ use crate::{
     Variant,
 };
 use std::{iter::Iterator, ptr::null_mut};
-use windows::core::BSTR;
+use windows::core::{BOOL, BSTR};
 use windows::Win32::System::Com::SAFEARRAY;
 use windows::Win32::System::Ole::{SafeArrayAccessData, SafeArrayUnaccessData};
 use windows::Win32::System::Variant::*;
@@ -116,6 +116,14 @@ pub unsafe fn safe_array_to_vec(arr: &SAFEARRAY, item_type: VARENUM) -> WMIResul
             accessor
                 .iter()
                 .map(|item| item.try_into().map(Variant::String).map_err(WMIError::from))
+                .collect()
+        }
+        VT_BOOL => {
+            let accessor = unsafe { SafeArrayAccessor::<BOOL>::new(arr)? };
+
+            accessor
+                .iter()
+                .map(|item| Ok(Variant::Bool(item.as_bool())))
                 .collect()
         }
         // TODO: Add support for all other types of arrays.


### PR DESCRIPTION
This PR adds support for array serialization.

There's a small problem with Boolean arrays and the safe array accessor, but otherwise it works as expected.

Fixes #118
