### PR TITLE
Added support for Option.

### DIFF
--- a/src/ser/variant_ser.rs
+++ b/src/ser/variant_ser.rs
@@ -111,19 +111,17 @@ impl<'a> Serializer for VariantSerializer<'a> {
     serialize_variant_err_stub!(serialize_char, char);
     serialize_variant_err_stub!(serialize_bytes, &[u8]);
 
+
+
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        Err(VariantSerializerError::UnsupportedVariantType(
-            "None".to_string(),
-        ))
+        Ok(Variant::Null)
     }
 
-    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
         T: ?Sized + Serialize,
     {
-        Err(VariantSerializerError::UnsupportedVariantType(
-            type_name::<T>().to_string(),
-        ))
+        value.serialize(self)
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -7,6 +7,7 @@ use windows::core::{IUnknown, Interface, BOOL, PCWSTR};
 use windows::Win32::Foundation::{VARIANT_FALSE, VARIANT_TRUE};
 use windows::Win32::System::Variant::*;
 use windows::Win32::System::Wmi::{self, IWbemClassObject, CIMTYPE_ENUMERATION};
+use windows::Win32::System::Variant::{VARIANT,   VT_NULL};
 
 #[derive(Debug, PartialEq, Serialize, Clone)]
 #[serde(untagged)]
@@ -273,6 +274,7 @@ impl Variant {
 
 impl TryFrom<Variant> for VARIANT {
     type Error = WMIError;
+    
     fn try_from(value: Variant) -> WMIResult<VARIANT> {
         match value {
             Variant::Empty => Ok(VARIANT::default()),
@@ -295,10 +297,13 @@ impl TryFrom<Variant> for VARIANT {
             Variant::Object(instance) => Ok(VARIANT::from(IUnknown::from(instance.inner))),
             Variant::Unknown(unknown) => Ok(VARIANT::from(unknown.inner)),
 
-            // windows-rs' VARIANT does not support creating these types of VARIANT at present
-            Variant::Null => Err(WMIError::ConvertVariantError(
-                "Cannot convert Variant::Null to a Windows VARIANT".to_string(),
-            )),
+            Variant::Null => {
+                let mut variant = unsafe { VariantInit() }; 
+                unsafe {
+                    std::ptr::write(&mut (*variant.Anonymous.Anonymous).vt, VT_NULL);
+                }
+                Ok(variant)
+            },
             Variant::Array(array) => {
                 // Variant arrays can only contain a single type, and we only support types that have utility functions in the `windows` crate.
                 match array.first() {

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -6,8 +6,8 @@ use std::convert::TryFrom;
 use windows::core::{IUnknown, Interface, BOOL, PCWSTR};
 use windows::Win32::Foundation::{VARIANT_FALSE, VARIANT_TRUE};
 use windows::Win32::System::Variant::*;
+use windows::Win32::System::Variant::{VARIANT, VT_NULL};
 use windows::Win32::System::Wmi::{self, IWbemClassObject, CIMTYPE_ENUMERATION};
-use windows::Win32::System::Variant::{VARIANT,   VT_NULL};
 
 #[derive(Debug, PartialEq, Serialize, Clone)]
 #[serde(untagged)]
@@ -274,7 +274,7 @@ impl Variant {
 
 impl TryFrom<Variant> for VARIANT {
     type Error = WMIError;
-    
+
     fn try_from(value: Variant) -> WMIResult<VARIANT> {
         match value {
             Variant::Empty => Ok(VARIANT::default()),
@@ -298,12 +298,12 @@ impl TryFrom<Variant> for VARIANT {
             Variant::Unknown(unknown) => Ok(VARIANT::from(unknown.inner)),
 
             Variant::Null => {
-                let mut variant = unsafe { VariantInit() }; 
+                let mut variant = unsafe { VariantInit() };
                 unsafe {
                     std::ptr::write(&mut (*variant.Anonymous.Anonymous).vt, VT_NULL);
                 }
                 Ok(variant)
-            },
+            }
             Variant::Array(array) => {
                 // Variant arrays can only contain a single type, and we only support types that have utility functions in the `windows` crate.
                 match array.first() {


### PR DESCRIPTION
@ohadravid  This is my attempt to add support for Option<>, testing with the example in the issue.

Seems correct, however I'm still getting an error for serialization of Some(). I am not sure if it's coming from my code or from the struct serialization code. Can you please take a quick look when you  have time, and reject my PR if the issue is in my code?

This works, until the commented line is uncommented. Then it generates a WMI error.


```rust
    let wmi_con = WMIConnection::with_namespace_path("ROOT\\cimv2", COMLibrary::new()?)?;

    let mut si = Win32ProcessStartup::default();
    // open window maximized
    // si.show_window = Some(3);   

    let input = CreateInput {
        command_line: "notepad.exe".to_string(),
        current_directory: "c:\\windows".into(),
        process_startup_information: si,
    };
```
