### PR TITLE
Fix conversions from variants to WMI numbers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wmi"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Ohad Ravid <ohad.rv@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/method.rs
+++ b/src/method.rs
@@ -224,7 +224,7 @@ mod tests {
 
     #[derive(Debug, Serialize, Default)]
     pub struct Win32_ProcessStartup {
-        CreateFlags: i32,
+        CreateFlags: u32,
     }
 
     #[derive(Serialize)]
@@ -268,7 +268,7 @@ mod tests {
     #[test]
     fn it_exec_methods() {
         let wmi_con = wmi_con();
-        const CREATE_SUSPENDED: i32 = 4;
+        const CREATE_SUSPENDED: u32 = 4;
 
         let in_params = CreateInput {
             CommandLine: "explorer.exe".to_string(),

--- a/src/result_enumerator.rs
+++ b/src/result_enumerator.rs
@@ -95,8 +95,8 @@ impl IWbemClassWrapper {
         Ok(())
     }
 
-    /// Get a method of this object. See [`crate::WMIConnection::exec_method`] for a usage example.
-    /// Note: GetMethod can only be called on a class definition.
+    /// Get the input signature class for the named method.
+    /// See [`crate::WMIConnection::exec_method`] for a usage example.
     /// See more at <https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemclassobject-getmethod>.
     ///
     /// The method may have no input parameters, such as in this case: <https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/reboot-method-in-class-win32-operatingsystem>.
@@ -118,6 +118,39 @@ impl IWbemClassWrapper {
         }
 
         Ok(input_signature.map(IWbemClassWrapper::new))
+    }
+
+    /// Get the input and output signature classes for the named method.
+    /// See [`crate::WMIConnection::exec_method`] for a usage example.
+    /// Note: GetMethod can only be called on a class definition.
+    /// See more at <https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemclassobject-getmethod>.
+    ///
+    /// The method may have no in or out parameters, such as in this case: <https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/reboot-method-in-class-win32-operatingsystem>.
+    /// In such cases, `None` is returned.
+    pub fn get_method_in_out(
+        &self,
+        name: impl AsRef<str>,
+    ) -> WMIResult<(Option<IWbemClassWrapper>, Option<IWbemClassWrapper>)> {
+        let method = BSTR::from(name.as_ref());
+
+        // Retrieve the input signature of the WMI method.
+        // The fields of the resulting IWbemClassObject will have the names and types of the WMI method's input parameters
+        let mut input_signature = None;
+        let mut output_signature = None;
+
+        unsafe {
+            self.inner.GetMethod(
+                &method,
+                Default::default(),
+                &mut input_signature,
+                &mut output_signature,
+            )?;
+        }
+
+        Ok((
+            input_signature.map(IWbemClassWrapper::new),
+            output_signature.map(IWbemClassWrapper::new),
+        ))
     }
 
     /// Create a new instance a class. See [`crate::WMIConnection::exec_method`] for a usage example.

--- a/src/safearray.rs
+++ b/src/safearray.rs
@@ -2,75 +2,18 @@ use crate::{
     utils::{WMIError, WMIResult},
     Variant,
 };
-use std::{iter::Iterator, ptr::null_mut};
+use std::{
+    iter::Iterator,
+    ptr::{null_mut, NonNull},
+};
 use windows::Win32::System::Com::SAFEARRAY;
 use windows::Win32::System::Ole::{SafeArrayAccessData, SafeArrayUnaccessData};
 use windows::Win32::System::Variant::*;
 use windows::{core::BSTR, Win32::Foundation::VARIANT_BOOL};
 
 #[derive(Debug)]
-pub struct SafeArrayAccessor<'a, T> {
-    arr: &'a SAFEARRAY,
-    p_data: *const T,
-}
-
-/// An accessor to SafeArray, which:
-/// 1. Locks the array so the data can be read.
-/// 2. Unlocks the array once dropped.
-///
-/// Pointers to a Safe Array can come from different places (like GetNames, WMI property value),
-/// which can have different drop behavior (GetNames require the caller to deallocate the array,
-/// while a WMI property must be deallocated via VariantClear).
-///
-/// For this reason, we don't have a `struct SafeArray`.
-///
-/// However, accessing the data of the array must be done using a lock, which is the responsibility
-/// of this struct.
-///
-impl<'a, T> SafeArrayAccessor<'a, T> {
-    /// Creates a new Accessor, locking the given array,
-    ///
-    /// # Safety
-    ///
-    /// This function is unsafe as it is the caller's responsibility to verify that the array is
-    /// of items of type T.
-    pub unsafe fn new(arr: &'a SAFEARRAY) -> WMIResult<Self> {
-        let mut p_data = null_mut();
-
-        if arr.cDims != 1 {
-            return Err(WMIError::UnimplementedArrayItem);
-        }
-
-        unsafe { SafeArrayAccessData(arr, &mut p_data)? };
-
-        Ok(Self {
-            arr,
-            p_data: p_data as *const T,
-        })
-    }
-
-    /// Return an iterator over the items of the array.
-    pub fn iter(&self) -> impl Iterator<Item = &'_ T> + '_ {
-        // Safety: We required the caller of `new` to ensure that the array is valid and contains only items of type T (and one dimensional).
-        // `SafeArrayAccessData` returns a pointer to the data of the array, which can be accessed for `arr.rgsabound[0].cElements` elements.
-        // See: https://learn.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-safearrayaccessdata#examples
-        let element_count = self.arr.rgsabound[0].cElements;
-
-        (0..element_count).map(move |i| unsafe { &*self.p_data.offset(i as isize) })
-    }
-}
-
-impl<'a, T> Drop for SafeArrayAccessor<'a, T> {
-    fn drop(&mut self) {
-        unsafe {
-            let _result = SafeArrayUnaccessData(self.arr);
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct SafeArrayMutAccessor<'a, T> {
-    arr: &'a mut SAFEARRAY,
+pub struct SafeArrayAccessor<T> {
+    arr: NonNull<SAFEARRAY>,
     p_data: *mut T,
 }
 
@@ -87,21 +30,21 @@ pub struct SafeArrayMutAccessor<'a, T> {
 /// However, accessing the data of the array must be done using a lock, which is the responsibility
 /// of this struct.
 ///
-impl<'a, T> SafeArrayMutAccessor<'a, T> {
+impl<T> SafeArrayAccessor<T> {
     /// Creates a new Accessor, locking the given array,
     ///
     /// # Safety
     ///
     /// This function is unsafe as it is the caller's responsibility to verify that the array is
     /// of items of type T.
-    pub unsafe fn new(arr: &'a mut SAFEARRAY) -> WMIResult<Self> {
+    pub unsafe fn new(arr: NonNull<SAFEARRAY>) -> WMIResult<Self> {
         let mut p_data = null_mut();
 
-        if arr.cDims != 1 {
+        if (*arr.as_ptr()).cDims != 1 {
             return Err(WMIError::UnimplementedArrayItem);
         }
 
-        unsafe { SafeArrayAccessData(arr, &mut p_data)? };
+        unsafe { SafeArrayAccessData(arr.as_ptr(), &mut p_data)? };
 
         Ok(Self {
             arr,
@@ -109,21 +52,37 @@ impl<'a, T> SafeArrayMutAccessor<'a, T> {
         })
     }
 
+    pub fn len(&self) -> u32 {
+        unsafe { (*self.arr.as_ptr()).rgsabound[0].cElements }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Return an iterator over the items of the array.
-    pub fn iter_mut(&'_ mut self) -> impl Iterator<Item = &'_ mut T> + use<'_, 'a, T> {
-        // Safety: We required the caller of `new` to ensure that the array is valid and contains only items of type T (and one dimensional).
+    pub fn iter(&self) -> impl Iterator<Item = &'_ T> + '_ {
+        // Safety: See `iter_mut()`.
+        let element_count = self.len();
+
+        (0..element_count).map(move |i| unsafe { &*self.p_data.offset(i as isize) })
+    }
+
+    /// Return an iterator over the items of the array.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &'_ mut T> + '_ {
+        // Safety: We required the caller of `new` to ensure that the array is valid and contains only items of type T (and is one dimensional).
         // `SafeArrayAccessData` returns a pointer to the data of the array, which can be accessed for `arr.rgsabound[0].cElements` elements.
         // See: https://learn.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-safearrayaccessdata#examples
-        let element_count = self.arr.rgsabound[0].cElements;
+        let element_count = self.len();
 
         (0..element_count).map(move |i| unsafe { &mut *self.p_data.offset(i as isize) })
     }
 }
 
-impl<'a, T> Drop for SafeArrayMutAccessor<'a, T> {
+impl<T> Drop for SafeArrayAccessor<T> {
     fn drop(&mut self) {
         unsafe {
-            let _result = SafeArrayUnaccessData(self.arr);
+            let _result = SafeArrayUnaccessData(self.arr.as_ptr());
         }
     }
 }
@@ -131,25 +90,26 @@ impl<'a, T> Drop for SafeArrayMutAccessor<'a, T> {
 /// # Safety
 ///
 /// The caller must ensure that the array is valid and contains only strings.
-pub unsafe fn safe_array_to_vec_of_strings(arr: &SAFEARRAY) -> WMIResult<Vec<String>> {
-    let items = safe_array_to_vec(arr, VT_BSTR)?;
+pub unsafe fn safe_array_to_vec_of_strings(arr: NonNull<SAFEARRAY>) -> WMIResult<Vec<String>> {
+    let accessor = unsafe { SafeArrayAccessor::<BSTR>::new(arr)? };
 
-    let string_items = items
-        .into_iter()
-        .map(|item| match item {
-            Variant::String(s) => s,
-            _ => unreachable!(),
-        })
-        .collect();
-
-    Ok(string_items)
+    accessor
+        .iter()
+        .map(|item| item.try_into().map_err(WMIError::from))
+        .collect()
 }
 
 /// # Safety
 ///
 /// The caller must ensure that the array is valid and contains elements on the specified type.
-pub unsafe fn safe_array_to_vec(arr: &SAFEARRAY, item_type: VARENUM) -> WMIResult<Vec<Variant>> {
-    fn copy_type_to_vec<T, F>(arr: &SAFEARRAY, variant_builder: F) -> WMIResult<Vec<Variant>>
+pub unsafe fn safe_array_to_vec(
+    arr: NonNull<SAFEARRAY>,
+    item_type: VARENUM,
+) -> WMIResult<Vec<Variant>> {
+    fn copy_type_to_vec<T, F>(
+        arr: NonNull<SAFEARRAY>,
+        variant_builder: F,
+    ) -> WMIResult<Vec<Variant>>
     where
         T: Copy,
         F: Fn(T) -> Variant,
@@ -171,21 +131,11 @@ pub unsafe fn safe_array_to_vec(arr: &SAFEARRAY, item_type: VARENUM) -> WMIResul
         VT_R4 => copy_type_to_vec(arr, Variant::R4),
         VT_R8 => copy_type_to_vec(arr, Variant::R8),
         VT_BSTR => {
-            let accessor = unsafe { SafeArrayAccessor::<BSTR>::new(arr)? };
+            let v = unsafe { safe_array_to_vec_of_strings(arr) }?;
 
-            accessor
-                .iter()
-                .map(|item| item.try_into().map(Variant::String).map_err(WMIError::from))
-                .collect()
+            Ok(v.into_iter().map(Variant::String).collect())
         }
-        VT_BOOL => {
-            let accessor = unsafe { SafeArrayAccessor::<VARIANT_BOOL>::new(arr)? };
-
-            accessor
-                .iter()
-                .map(|item| Ok(Variant::Bool(item.as_bool())))
-                .collect()
-        }
+        VT_BOOL => copy_type_to_vec::<VARIANT_BOOL, _>(arr, |item| Variant::Bool(item.as_bool())),
         // TODO: Add support for all other types of arrays.
         _ => Err(WMIError::UnimplementedArrayItem),
     }

--- a/src/ser/variant_ser.rs
+++ b/src/ser/variant_ser.rs
@@ -534,8 +534,8 @@ mod tests {
         #[derive(Debug, Serialize, Default)]
         pub struct Win32_ProcessStartup {
             pub Title: String,
-            pub ShowWindow: Option<i16>,
-            pub CreateFlags: Option<i32>,
+            pub ShowWindow: Option<u16>,
+            pub CreateFlags: Option<u32>,
         }
 
         #[derive(Deserialize)]

--- a/src/ser/variant_ser.rs
+++ b/src/ser/variant_ser.rs
@@ -277,11 +277,10 @@ impl<'a> SerializeSeq for VariantSeqSerializer<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::{ptr, u32, u64, u8};
-
     use super::*;
     use crate::tests::fixtures::wmi_con;
     use serde::{Deserialize, Serialize};
+    use std::ptr;
     use windows::core::HSTRING;
     use windows::Win32::System::Wmi::{CIM_FLAG_ARRAY, CIM_SINT64, CIM_UINT64};
 

--- a/src/ser/variant_ser.rs
+++ b/src/ser/variant_ser.rs
@@ -277,9 +277,13 @@ impl<'a> SerializeSeq for VariantSeqSerializer<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::{ptr, u32, u64, u8};
+
     use super::*;
     use crate::tests::fixtures::wmi_con;
     use serde::{Deserialize, Serialize};
+    use windows::core::HSTRING;
+    use windows::Win32::System::Wmi::{CIM_FLAG_ARRAY, CIM_SINT64, CIM_UINT64};
 
     #[test]
     fn it_serialize_instance() {
@@ -338,6 +342,188 @@ mod tests {
         assert_eq!(
             instance_from_ser.get_property("sSubKeyName").unwrap(),
             Variant::String(in_params.sSubKeyName)
+        );
+    }
+
+    fn spawn_instance(name: &str) -> IWbemClassWrapper {
+        let wmi_con = wmi_con();
+        wmi_con.get_object(&name).unwrap().spawn_instance().unwrap()
+    }
+
+    #[test]
+    fn it_can_get_and_put_strings() {
+        let prop = spawn_instance("Win32_PnPDevicePropertyString");
+        let test_value = Variant::String("Some Title".to_string());
+
+        prop.put_property("Data", test_value.clone()).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), test_value,);
+
+        let prop = spawn_instance("Win32_PnPDevicePropertyStringArray");
+        let test_value = Variant::Array(vec![
+            Variant::String("X".to_string()),
+            Variant::String("a".to_string()),
+        ]);
+        prop.put_property("Data", test_value.clone()).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), test_value,);
+    }
+
+    #[test]
+    fn it_can_get_and_put_numbers_and_bool() {
+        let prop = spawn_instance("Win32_PnPDevicePropertyBoolean");
+        prop.put_property("Data", true).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), Variant::Bool(true));
+
+        let prop = spawn_instance("Win32_PnPDevicePropertyUint8");
+        prop.put_property("Data", u8::MAX).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), Variant::UI1(u8::MAX));
+
+        let prop = spawn_instance("Win32_PnPDevicePropertyUint16");
+        prop.put_property("Data", u16::MAX).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), Variant::UI2(u16::MAX));
+
+        let prop = spawn_instance("Win32_PnPDevicePropertyUint32");
+        prop.put_property("Data", u32::MAX).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), Variant::UI4(u32::MAX));
+
+        let prop = spawn_instance("Win32_PnPDevicePropertyUint64");
+        prop.put_property("Data", u64::MAX).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), Variant::UI8(u64::MAX));
+
+        let prop = spawn_instance("Win32_PnPDevicePropertySint8");
+        prop.put_property("Data", i8::MAX).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), Variant::I1(i8::MAX));
+        prop.put_property("Data", i8::MIN).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), Variant::I1(i8::MIN));
+
+        let prop = spawn_instance("Win32_PnPDevicePropertySint16");
+        prop.put_property("Data", i16::MAX).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), Variant::I2(i16::MAX));
+        prop.put_property("Data", i16::MIN).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), Variant::I2(i16::MIN));
+
+        let prop = spawn_instance("Win32_PnPDevicePropertySint32");
+        prop.put_property("Data", i32::MAX).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), Variant::I4(i32::MAX));
+        prop.put_property("Data", i32::MIN).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), Variant::I4(i32::MIN));
+
+        let prop = spawn_instance("Win32_PnPDevicePropertySint64");
+        prop.put_property("Data", i64::MAX).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), Variant::I8(i64::MAX));
+        prop.put_property("Data", i64::MIN).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), Variant::I8(i64::MIN));
+
+        let prop = spawn_instance("Win32_PnPDevicePropertyReal32");
+        prop.put_property("Data", 1.0f32).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), Variant::R4(1.0));
+
+        let prop = spawn_instance("Win32_PnPDevicePropertyReal64");
+        prop.put_property("Data", 1.0f64).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), Variant::R8(1.0));
+    }
+
+    #[test]
+    fn it_can_get_and_put_arrays() {
+        let prop = spawn_instance("Win32_PnPDevicePropertyBooleanArray");
+        let test_value = vec![true, false, true];
+        prop.put_property("Data", test_value.clone()).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), test_value.into());
+
+        // Test with an empty array as well.
+        let prop = spawn_instance("Win32_PnPDevicePropertyBooleanArray");
+        let test_value = Variant::Array(vec![]);
+        prop.put_property("Data", test_value.clone()).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), test_value.into());
+
+        let prop = spawn_instance("Win32_PnPDevicePropertyBinary");
+        let test_value = vec![1u8, 2, u8::MAX];
+        prop.put_property("Data", test_value.clone()).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), test_value.into());
+
+        let prop = spawn_instance("Win32_PnPDevicePropertyUint16Array");
+        let test_value = vec![1u16, 2, u16::MAX];
+        prop.put_property("Data", test_value.clone()).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), test_value.into());
+
+        let prop = spawn_instance("Win32_PnPDevicePropertyUint32Array");
+        let test_value = vec![1u32, 2, u32::MAX];
+        prop.put_property("Data", test_value.clone()).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), test_value.into());
+
+        let prop = spawn_instance("Win32_PnPDevicePropertySint8Array");
+        let test_value = vec![1i8, i8::MIN, i8::MAX];
+        prop.put_property("Data", test_value.clone()).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), test_value.into());
+
+        let prop = spawn_instance("Win32_PnPDevicePropertySint16Array");
+        let test_value = vec![1i16, i16::MIN, i16::MAX];
+        prop.put_property("Data", test_value.clone()).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), test_value.into());
+
+        let prop = spawn_instance("Win32_PnPDevicePropertySint32Array");
+        let test_value = vec![1i32, i32::MIN, i32::MAX];
+        prop.put_property("Data", test_value.clone()).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), test_value.into());
+
+        let prop = spawn_instance("Win32_PnPDevicePropertyReal32Array");
+        let test_value = vec![1.0f32, 2.0, -1.0];
+        prop.put_property("Data", test_value.clone()).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), test_value.into());
+
+        let prop = spawn_instance("Win32_PnPDevicePropertyReal64Array");
+        let test_value = vec![1.0f64, 2.0, -1.0];
+        prop.put_property("Data", test_value.clone()).unwrap();
+        assert_eq!(prop.get_property("Data").unwrap(), test_value.into());
+    }
+
+    #[test]
+    fn it_can_get_and_put_u64_i64_arrays() {
+        // Since `Win32_PnPDeviceProperty{Uint64,Sint64}Array` are missing (documented, but do not exist in practice),
+        // we create a new class and set custom properties with the needed array types.
+
+        let wmi_con = wmi_con();
+        let new_cls_obj = wmi_con.get_object("").unwrap();
+
+        unsafe {
+            new_cls_obj
+                .inner
+                .Put(
+                    &HSTRING::from("uValue"),
+                    0,
+                    ptr::null(),
+                    CIM_UINT64.0 | CIM_FLAG_ARRAY.0,
+                )
+                .unwrap()
+        };
+
+        let test_value = vec![1u64, 2, u64::MAX];
+        new_cls_obj
+            .put_property("uValue", test_value.clone())
+            .unwrap();
+        assert_eq!(
+            new_cls_obj.get_property("uValue").unwrap(),
+            test_value.into()
+        );
+
+        unsafe {
+            new_cls_obj
+                .inner
+                .Put(
+                    &HSTRING::from("iValue"),
+                    0,
+                    ptr::null(),
+                    CIM_SINT64.0 | CIM_FLAG_ARRAY.0,
+                )
+                .unwrap()
+        };
+
+        let test_value = vec![1i64, i64::MIN, i64::MAX];
+        new_cls_obj
+            .put_property("iValue", test_value.clone())
+            .unwrap();
+        assert_eq!(
+            new_cls_obj.get_property("iValue").unwrap(),
+            test_value.into()
         );
     }
 
@@ -404,19 +590,19 @@ mod tests {
         };
 
         // Similar to how `exec_class_method` creates these objects.
-        let method_instance = wmi_con
+        let (method_in, method_out) = wmi_con
             .get_object("Win32_Process")
             .unwrap()
-            .get_method("Create")
-            .unwrap()
-            .unwrap()
-            .spawn_instance()
+            .get_method_in_out("Create")
             .unwrap();
+
+        let method_in = method_in.unwrap().spawn_instance().unwrap();
+        let method_out = method_out.unwrap().spawn_instance().unwrap();
 
         let instance_from_ser = create_params
             .serialize(VariantSerializer {
                 wmi: &wmi_con,
-                instance: Some(method_instance),
+                instance: Some(method_in),
             })
             .unwrap();
 
@@ -436,5 +622,10 @@ mod tests {
                 .unwrap(),
             Variant::Object(_)
         ));
+
+        assert_eq!(
+            method_out.get_property("ReturnValue").unwrap(),
+            Variant::Null
+        );
     }
 }


### PR DESCRIPTION
This PR fixes the implementation used to convert **from** Rust types **to** WMI types (so, only when used for method calling or using `put_property`), which was incorrect in a few cases (noteably, `u32`s and `u16`s were not converted correctly). It also adds some missing conversions.

These are the rules the govern WMI's usage of `VARIANT`s:

1. The documentation in https://learn.microsoft.com/en-us/windows/win32/wmisdk/numbers says:

### Numbers (WMI)


| Data type  | Automation type | Description                                                                                                                                                             |
|------------|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| **sint8**  | **VT\_I2**      | Signed 8-bit integer.<br/>                                                                                                                                        |
| **sint16** | **VT\_I2**      | Signed 16-bit integer.<br/>                                                                                                                                       |
| **sint32** | VT\_I4          | Signed 32-bit integer.<br/>                                                                                                                                       |
| **sint64** | **VT\_BSTR**    | Signed 64-bit integer in string form. This type follows hexadecimal or decimal format according to the American National Standards Institute (ANSI) C rules.<br/> |
| **real32** | **VT\_R4**      | 4-byte floating-point value that follows the Institute of Electrical and Electronics Engineers, Inc. (IEEE) standard.<br/>                                        |
| **real64** | **VT\_R8**      | 8-byte floating-point value that follows the IEEE standard.<br/>                                                                                                  |
| **uint8**  | **VT\_UI1**     | Unsigned 8-bit integer.<br/>                                                                                                                                      |
| **uint16** | **VT\_I4**      | Unsigned 16-bit integer.<br/>                                                                                                                                     |
| **uint32** | **VT\_I4**      | Unsigned 32-bit integer.<br/>                                                                                                                                     |
| **uint64** | **VT\_BSTR**    | Unsigned 64-bit integer in string form. This type follows hexadecimal or decimal format according to ANSI C rules.<br/>

2. The documentation in https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemclassobject-put#examples says:

> The following code example shows how to set the value of the SomeUint64 property. Be aware that the BSTR value must be in decimal format and not hexadecimal.

3. These rules apply for arrays as well (so a `Vec<u64>` should be passed in as an array of strings, and a `Vec<i8>` should be passed in as an array of u16, etc).

This also means that for `Variant -> VARIANT -> Variant` conversion to be lossless, the caller must use `convert_into_cim_type`, as done in `it_convert_array_to_ms_variant`.

## Breaking Changes

This PR also updates the `SafeArrayAccessor`'s API to use a pointer and not a reference.