### PR TITLE
VT_UNKNOWN arrays require add-ref/cloning the items

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -897,8 +897,6 @@ mod tests {
         let wmi_con = wmi_con();
         let classes = [
             "CIM_ComputerSystem",
-            "Win32_Service",
-            "Win32_Process",
             "Win32_OperatingSystem",
             "Win32_TimeZone",
             "Win32_ComputerSystem",
@@ -911,9 +909,7 @@ mod tests {
             "Win32_Share",
             "Win32_MappedLogicalDisk",
             "Win32_DiskDrive",
-            "Win32_Product",
             "Win32_IP4RouteTable",
-            "Win32_NetworkConnection",
             "Win32_Group",
             // Only works under 64bit.
             // "Win32_ShadowCopy",

--- a/src/result_enumerator.rs
+++ b/src/result_enumerator.rs
@@ -69,12 +69,11 @@ impl IWbemClassWrapper {
                 Some(&mut cim_type),
                 None,
             )?;
-
-            let property_value = Variant::from_variant(&vt_prop)?
-                .convert_into_cim_type(CIMTYPE_ENUMERATION(cim_type))?;
-
-            Ok(property_value)
         }
+
+        let property_value = Variant::from_variant(&vt_prop)?;
+
+        property_value.convert_into_cim_type(CIMTYPE_ENUMERATION(cim_type))
     }
 
     /// Set the value of a property.

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -587,7 +587,7 @@ impl TryFrom<Variant> for () {
 }
 
 /// A wrapper around the [`IUnknown`] interface. \
-/// Used to retrive [`IWbemClassObject`][winapi::um::Wmi::IWbemClassObject]
+/// Used to retrieve [`IWbemClassObject`][winapi::um::Wmi::IWbemClassObject]
 ///
 #[repr(transparent)]
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -596,7 +596,7 @@ pub struct IUnknownWrapper {
 }
 
 impl IUnknownWrapper {
-    /// Wrapps around a non-null pointer to IUnknown
+    /// Wraps a non-null pointer to IUnknown
     ///
     pub fn new(ptr: IUnknown) -> Self {
         IUnknownWrapper { inner: ptr }


### PR DESCRIPTION
Followup to #125 (cc @samin-cf): According to the docs (e.g, [VariantClear](https://learn.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-variantclear)), after getting the array of `IUnkown` objects, we need to `AddRef` to them if we want to use them after the array is cleared.

So I switched to `IUnknown::from_raw_borrowed(..).cloned()` which handles this correctly.