### PR TITLE
Remove `COMLibrary` and let `WMIConnection` init COM if needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wmi"
-version = "0.17.3"
+version = "0.18.0"
 authors = ["Ohad Ravid <ohad.rv@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -49,6 +49,7 @@ tokio = { version = "1", features = ["rt", "macros"] }
 serde_json = { version = "1.0" }
 criterion = "0.7"
 tempdir = "0.3"
+rusty-fork = "0.3.0"
 
 [[bin]]
 name = "wmiq"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ WMI (Windows Management Instrumentation) crate for rust.
 ```toml
 # Cargo.toml
 [dependencies]
-wmi = "*"
+wmi = "0.18"
 ```
 
 ## Examples
@@ -21,12 +21,11 @@ Queries can be deserialized into a free-form `HashMap` or a `struct`:
 #![allow(non_snake_case)]
 
 use serde::Deserialize;
-use wmi::{COMLibrary, Variant, WMIConnection, WMIDateTime};
+use wmi::{Variant, WMIConnection, WMIDateTime};
 use std::collections::HashMap;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let com_con = COMLibrary::new()?;
-    let wmi_con = WMIConnection::new(com_con.into())?;
+    let wmi_con = WMIConnection::new()?;
 
     let results: Vec<HashMap<String, Variant>> = wmi_con.raw_query("SELECT * FROM Win32_OperatingSystem")?;
 
@@ -76,13 +75,12 @@ like [ExecAsyncQuery](https://docs.microsoft.com/en-us/windows/win32/api/wbemcli
 #![allow(non_snake_case)]
 
 use serde::Deserialize;
-use wmi::{COMLibrary, Variant, WMIConnection, WMIDateTime};
+use wmi::{Variant, WMIConnection, WMIDateTime};
 use std::collections::HashMap;
 use futures::executor::block_on;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let com_con = COMLibrary::new()?;
-    let wmi_con = WMIConnection::new(com_con.into())?;
+    let wmi_con = WMIConnection::new()?;
 
     block_on(exec_async_query(&wmi_con))?;
 

--- a/src/async_query.rs
+++ b/src/async_query.rs
@@ -67,7 +67,7 @@ impl WMIConnection {
     /// # }
     /// #
     /// # async fn exec_async_query() -> WMIResult<()> {
-    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// # let con = WMIConnection::new()?;
     /// use futures::stream::TryStreamExt;
     /// let results: Vec<HashMap<String, Variant>> = con.async_raw_query("SELECT Name FROM Win32_OperatingSystem").await?;
     /// #   Ok(())
@@ -98,7 +98,7 @@ impl WMIConnection {
     /// # }
     /// #
     /// # async fn exec_async_query() -> WMIResult<()> {
-    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// # let con = WMIConnection::new()?;
     /// use serde::Deserialize;
     /// #[derive(Deserialize, Debug)]
     /// struct Win32_Process {

--- a/src/benches/benchmark.rs
+++ b/src/benches/benchmark.rs
@@ -3,7 +3,7 @@
 use criterion::{Criterion, criterion_group};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use wmi::{COMLibrary, Variant, WMIConnection};
+use wmi::{Variant, WMIConnection};
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename = "Win32_Account")]
@@ -108,54 +108,52 @@ fn get_services(con: &WMIConnection) {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let com = COMLibrary::new().unwrap();
-
     // baseline: 41ms
     c.bench_function("get_accounts", |b| {
-        let wmi_con = WMIConnection::new(com).unwrap();
+        let wmi_con = WMIConnection::new().unwrap();
         b.iter(|| get_accounts(&wmi_con))
     });
 
     // baseline: 13ms
     c.bench_function("get_user_accounts", |b| {
-        let wmi_con = WMIConnection::new(com).unwrap();
+        let wmi_con = WMIConnection::new().unwrap();
         b.iter(|| get_user_accounts(&wmi_con))
     });
 
     // baseline: 9ms
     c.bench_function("get_user_accounts_hash_map", |b| {
-        let wmi_con = WMIConnection::new(com).unwrap();
+        let wmi_con = WMIConnection::new().unwrap();
         b.iter(|| get_user_accounts_hash_map(&wmi_con))
     });
 
     // baseline: 60ms
     c.bench_function("get_minimal_procs", |b| {
-        let wmi_con = WMIConnection::new(com).unwrap();
+        let wmi_con = WMIConnection::new().unwrap();
         b.iter(|| get_minimal_procs(&wmi_con))
     });
 
     // baseline: 68ms
     c.bench_function("get_procs_hash_map", |b| {
-        let wmi_con = WMIConnection::new(com).unwrap();
+        let wmi_con = WMIConnection::new().unwrap();
         b.iter(|| get_procs_hash_map(&wmi_con))
     });
 
     // baseline: 9s (**seconds**)
     // after adding AssocClass: 73ms
     c.bench_function("get_users_with_groups", |b| {
-        let wmi_con = WMIConnection::new(com).unwrap();
+        let wmi_con = WMIConnection::new().unwrap();
         b.iter(|| get_users_with_groups(&wmi_con))
     });
 
     // baseline: 625ms.
     c.bench_function("get_modules", |b| {
-        let wmi_con = WMIConnection::new(com).unwrap();
+        let wmi_con = WMIConnection::new().unwrap();
         b.iter(|| get_modules(&wmi_con))
     });
 
     // baseline: 300ms.
     c.bench_function("get_services", |b| {
-        let wmi_con = WMIConnection::new(com).unwrap();
+        let wmi_con = WMIConnection::new().unwrap();
         b.iter(|| get_services(&wmi_con))
     });
 }

--- a/src/bin/wmiq.rs
+++ b/src/bin/wmiq.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, env::args};
-use wmi::{COMLibrary, Variant, WMIConnection, WMIResult};
+use wmi::{Variant, WMIConnection, WMIResult};
 
 fn main() -> WMIResult<()> {
-    let wmi_con = WMIConnection::new(COMLibrary::new()?)?;
+    let wmi_con = WMIConnection::new()?;
     let args: Vec<String> = args().collect();
     let query = match args.get(1) {
         None => {

--- a/src/context.rs
+++ b/src/context.rs
@@ -89,14 +89,11 @@ impl_from_type!(bool, Bool);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::COMLibrary;
     use serde::Deserialize;
 
     #[test]
     fn verify_ctx_values_used() {
-        let com_con = COMLibrary::new().unwrap();
-        let mut wmi_con =
-            WMIConnection::with_namespace_path("ROOT\\StandardCimv2", com_con).unwrap();
+        let mut wmi_con = WMIConnection::with_namespace_path("ROOT\\StandardCimv2").unwrap();
 
         #[derive(Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug)]
         struct MSFT_NetAdapter {
@@ -120,9 +117,7 @@ mod tests {
 
     #[tokio::test]
     async fn async_verify_ctx_values_used() {
-        let com_con = COMLibrary::new().unwrap();
-        let mut wmi_con =
-            WMIConnection::with_namespace_path("ROOT\\StandardCimv2", com_con).unwrap();
+        let mut wmi_con = WMIConnection::with_namespace_path("ROOT\\StandardCimv2").unwrap();
 
         #[derive(Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug)]
         struct MSFT_NetAdapter {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,8 @@
 //!
 //! ```rust
 //! # fn main() -> wmi::WMIResult<()> {
-//! use wmi::{COMLibrary, WMIConnection};
-//! let com_con = COMLibrary::new()?;
-//! let wmi_con = WMIConnection::new(com_con)?;
+//! use wmi::WMIConnection;
+//! let wmi_con = WMIConnection::new()?;
 //! #   Ok(())
 //! # }
 //! ```
@@ -26,14 +25,14 @@
 //! WMI data model is based on COM's [`VARIANT`] Type, which is a struct capable of holding
 //! many types of data.
 //!
-//! This crate provides the analogous [`crate::Variant`] enum.
+//! This crate provides the analogous [`wmi::Variant`] enum.
 //!
 //! Using this enum, we can execute a simple WMI query and inspect the results.
 //!
 //! ```edition2018
 //! # fn main() -> wmi::WMIResult<()> {
 //! use wmi::*;
-//! let wmi_con = WMIConnection::new(COMLibrary::new()?)?;
+//! let wmi_con = WMIConnection::new()?;
 //! use std::collections::HashMap;
 //! use wmi::Variant;
 //! let results: Vec<HashMap<String, Variant>> = wmi_con.raw_query("SELECT * FROM Win32_OperatingSystem").unwrap();
@@ -52,7 +51,7 @@
 //! ```edition2018
 //! # fn main() -> wmi::WMIResult<()> {
 //! # use wmi::*;
-//! # let wmi_con = WMIConnection::new(COMLibrary::new()?)?;
+//! # let wmi_con = WMIConnection::new()?;
 //! use serde::Deserialize;
 //! # #[cfg(feature = "chrono")]
 //! use wmi::WMIDateTime;
@@ -132,7 +131,7 @@
 //! # fn main() -> WMIResult<()>{
 //! # use serde::Deserialize;
 //! # use std::{collections::HashMap, time::Duration};
-//! # let wmi_con = WMIConnection::new(COMLibrary::new()?)?;
+//! # let wmi_con = WMIConnection::new()?;
 //! #[derive(Deserialize, Debug)]
 //! #[serde(rename = "__InstanceCreationEvent")]
 //! #[serde(rename_all = "PascalCase")]
@@ -181,7 +180,7 @@
 //! # fn run() -> WMIResult<()>{
 //! # use serde::Deserialize;
 //! # use std::{collections::HashMap, time::Duration};
-//! # let wmi_con = WMIConnection::new(COMLibrary::new()?)?;
+//! # let wmi_con = WMIConnection::new()?;
 //! #[derive(Deserialize, Debug)]
 //! #[serde(rename = "Win32_ProcessStartTrace")]
 //! #[serde(rename_all = "PascalCase")]
@@ -248,7 +247,7 @@
 //! # block_on(exec_async_query()).unwrap();
 //! # async fn exec_async_query() -> wmi::WMIResult<()> {
 //! use wmi::*;
-//! let wmi_con = WMIConnection::new(COMLibrary::new()?)?;
+//! let wmi_con = WMIConnection::new()?;
 //! use serde::Deserialize;
 //!
 //! #[derive(Deserialize, Debug)]
@@ -302,7 +301,7 @@ mod notification;
 #[cfg(any(test, feature = "test"))]
 pub mod tests;
 
-pub use connection::{COMLibrary, WMIConnection};
+pub use connection::WMIConnection;
 
 #[cfg(feature = "chrono")]
 pub use datetime::WMIDateTime;

--- a/src/method.rs
+++ b/src/method.rs
@@ -19,9 +19,9 @@ impl WMIConnection {
     ///
     /// ```edition2021
     /// # use std::collections::HashMap;
-    /// # use wmi::{COMLibrary, Variant, WMIConnection, WMIResult};
+    /// # use wmi::{Variant, WMIConnection, WMIResult};
     /// # fn main() -> WMIResult<()> {
-    /// # let wmi_con = WMIConnection::new(COMLibrary::new()?)?;
+    /// # let wmi_con = WMIConnection::new()?;
     /// let in_params = wmi_con
     ///     .get_object("Win32_Process")?
     ///     .get_method("Create")?
@@ -76,7 +76,7 @@ impl WMIConnection {
     ///
     /// ```edition2021
     /// # use serde::{Deserialize, Serialize};
-    /// # use wmi::{COMLibrary, Variant, WMIConnection, WMIResult};
+    /// # use wmi::{Variant, WMIConnection, WMIResult};
     /// #[derive(Serialize)]
     /// # #[allow(non_snake_case)]
     /// struct CreateInput {
@@ -95,7 +95,7 @@ impl WMIConnection {
     /// struct Win32_Process;
     ///
     /// # fn main() -> WMIResult<()> {
-    /// # let wmi_con = WMIConnection::new(COMLibrary::new()?)?;
+    /// # let wmi_con = WMIConnection::new()?;
     /// // Note: The Create call can be unreliable, so consider using another means of starting processes.
     /// let input = CreateInput {
     ///     CommandLine: "explorer.exe".to_string()
@@ -134,7 +134,7 @@ impl WMIConnection {
     ///
     /// ```edition2021
     /// # use serde::{Deserialize, Serialize};
-    /// # use wmi::{COMLibrary, FilterValue, Variant, WMIConnection, WMIResult};
+    /// # use wmi::{FilterValue, Variant, WMIConnection, WMIResult};
     /// #[derive(Deserialize)]
     /// # #[allow(non_snake_case)]
     /// struct PrinterOutput {
@@ -148,7 +148,7 @@ impl WMIConnection {
     /// }
     ///
     /// # fn main() -> WMIResult<()> {
-    /// # let wmi_con = WMIConnection::new(COMLibrary::new()?)?;
+    /// # let wmi_con = WMIConnection::new()?;
     /// let printers: Vec<Win32_Printer> = wmi_con.query()?;
     ///
     /// for printer in printers {

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -51,7 +51,7 @@ impl WMIConnection {
     /// # }
     /// # fn run() -> wmi::WMIResult<()> {
     /// # use std::collections::HashMap;
-    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// # let con = WMIConnection::new()?;
     /// let iterator = con.raw_notification::<HashMap<String, Variant>>("SELECT ProcessID, ProcessName FROM Win32_ProcessStartTrace")?;
     /// #   Ok(()) // This query will fail when not run as admin
     /// # }
@@ -84,7 +84,7 @@ impl WMIConnection {
     /// # fn run() -> wmi::WMIResult<()> {
     /// use serde::Deserialize;
     ///
-    /// let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// let con = WMIConnection::new()?;
     ///
     /// #[derive(Deserialize, Debug)]
     /// struct Win32_ProcessStartTrace {
@@ -111,7 +111,7 @@ impl WMIConnection {
     /// # fn main() -> wmi::WMIResult<()> {
     /// # use std::{collections::HashMap, time::Duration};
     /// # use wmi::*;
-    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// # let con = WMIConnection::new()?;
     /// use serde::Deserialize;
     /// #[derive(Deserialize, Debug)]
     /// struct __InstanceCreationEvent {
@@ -198,7 +198,7 @@ impl WMIConnection {
     /// # }
     /// #
     /// # async fn exec_async_query() -> WMIResult<()> {
-    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// # let con = WMIConnection::new()?;
     /// let mut stream = con.async_raw_notification::<HashMap<String, Variant>>("SELECT ProcessID, ProcessName FROM Win32_ProcessStartTrace")?;
     /// # let event = stream.next().await.unwrap()?;
     /// #   Ok(()) // This query will fail when not run as admin
@@ -234,7 +234,7 @@ impl WMIConnection {
     /// # }
     /// #
     /// # async fn exec_async_query() -> WMIResult<()> {
-    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// # let con = WMIConnection::new()?;
     /// use futures::StreamExt;
     /// use serde::Deserialize;
     ///
@@ -275,7 +275,7 @@ impl WMIConnection {
     /// #
     /// # async fn exec_async_query() -> WMIResult<()> {
     /// # use std::{collections::HashMap, time::Duration};
-    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// # let con = WMIConnection::new()?;
     /// use futures::StreamExt;
     /// use serde::Deserialize;
     /// #[derive(Deserialize, Debug)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -293,7 +293,7 @@ impl WMIConnection {
     /// # fn main() -> wmi::WMIResult<()> {
     /// # use std::collections::HashMap;
     /// # use wmi::*;
-    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// # let con = WMIConnection::new()?;
     /// let results: Vec<HashMap<String, Variant>> = con.raw_query("SELECT Name FROM Win32_OperatingSystem")?;
     /// #   Ok(())
     /// # }
@@ -319,7 +319,7 @@ impl WMIConnection {
     /// use wmi::*;
     /// use serde::Deserialize;
     ///
-    /// let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// let con = WMIConnection::new()?;
     ///
     /// #[derive(Deserialize, Debug)]
     /// struct Win32_Process {
@@ -345,7 +345,7 @@ impl WMIConnection {
     /// # fn main() -> wmi::WMIResult<()> {
     /// # use std::collections::HashMap;
     /// # use wmi::*;
-    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// # let con = WMIConnection::new()?;
     /// use serde::Deserialize;
     /// #[derive(Deserialize, Debug)]
     /// struct Win32_Process {
@@ -377,7 +377,7 @@ impl WMIConnection {
     ///
     /// ```edition2018
     /// # fn main() -> wmi::WMIResult<()> {
-    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// # let con = WMIConnection::new()?;
     /// # use wmi::*;
     /// use serde::Deserialize;
     /// #[derive(Deserialize)]
@@ -406,7 +406,7 @@ impl WMIConnection {
     /// # fn main() -> wmi::WMIResult<()> {
     /// # use wmi::*;
     /// # use serde::Deserialize;
-    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// # let con = WMIConnection::new()?;
     /// let raw_os = con.get_object(r#"\\.\root\cimv2:Win32_OperatingSystem=@"#)?;
     /// assert_eq!(raw_os.class()?, "Win32_OperatingSystem");
     ///
@@ -449,7 +449,7 @@ impl WMIConnection {
     /// # fn main() -> wmi::WMIResult<()> {
     /// # use wmi::*;
     /// # use serde::Deserialize;
-    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// # let con = WMIConnection::new()?;
     /// #[derive(Deserialize)]
     /// struct Win32_OperatingSystem {
     ///     Name: String,
@@ -468,7 +468,7 @@ impl WMIConnection {
     /// # use std::collections::HashMap;
     /// # use wmi::*;
     /// # use serde::Deserialize;
-    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// # let con = WMIConnection::new()?;
     ///
     /// #[derive(Deserialize, Debug, PartialEq)]
     /// struct Win32_Group {
@@ -541,7 +541,7 @@ impl WMIConnection {
     /// # fn main() -> wmi::WMIResult<()> {
     /// # use wmi::*;
     /// # use serde::Deserialize;
-    /// # let con = WMIConnection::new(COMLibrary::new()?)?;
+    /// # let con = WMIConnection::new()?;
     ///
     /// #[derive(Deserialize, Debug)]
     /// struct Win32_DiskDrive {

--- a/src/safearray.rs
+++ b/src/safearray.rs
@@ -149,6 +149,7 @@ pub unsafe fn safe_array_to_vec(
             accessor
                 .iter()
                 .map(|item| {
+                    // Safety: `VT_UNKNOWN` means we know each item is a valid COM interface.
                     unsafe { IUnknown::from_raw_borrowed(item) }
                         .cloned()
                         .map(|item| Variant::Unknown(IUnknownWrapper::new(item)))

--- a/src/ser/variant_ser.rs
+++ b/src/ser/variant_ser.rs
@@ -279,7 +279,7 @@ impl<'a> SerializeSeq for VariantSeqSerializer<'a> {
 mod tests {
     use super::*;
     use crate::tests::fixtures::wmi_con;
-    use serde::{Deserialize, Serialize};
+    use serde::Serialize;
     use std::ptr;
     use windows::Win32::System::Wmi::{CIM_FLAG_ARRAY, CIM_SINT64, CIM_UINT64};
     use windows::core::HSTRING;
@@ -287,9 +287,6 @@ mod tests {
     #[test]
     fn it_serialize_instance() {
         let wmi_con = wmi_con();
-
-        #[derive(Deserialize)]
-        struct StdRegProv;
 
         #[derive(Serialize)]
         struct GetBinaryValue {
@@ -536,9 +533,6 @@ mod tests {
             pub ShowWindow: Option<u16>,
             pub CreateFlags: Option<u32>,
         }
-
-        #[derive(Deserialize)]
-        struct Win32_Process;
 
         #[derive(Serialize)]
         struct CreateInput {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,17 +1,10 @@
-use crate::{COMLibrary, WMIConnection, WMIError, WMIResult};
+use crate::{WMIConnection, WMIError, WMIResult};
 
 pub mod fixtures {
     use super::*;
 
-    // This way we only setup COM security once per thread during tests.
-    thread_local! {
-        static COM_LIB: COMLibrary = COMLibrary::without_security().unwrap();
-    }
-
     pub fn wmi_con() -> WMIConnection {
-        let com_lib = COM_LIB.with(|com| *com);
-
-        WMIConnection::new(com_lib).unwrap()
+        WMIConnection::new().unwrap()
     }
 }
 


### PR DESCRIPTION
- Remove `COMLibrary`
- `WMIConnection` will initialize COM if it isn't initialized
- COM initialization is done using `CoIncrementMTAUsage` instead of `CoInitializeEx`

~Minor drive-by changes: update to 2024 edition, `cargo fmt`.~

Fixes #136 - tested in `it_can_run_as_thread_local_in_non_main_thread`

See also: https://kennykerrca.wordpress.com/2018/03/24/cppwinrt-hosting-the-windows-runtime/
Based the same logic used in `load_factory` in windows-rs by @kennykerr: 
https://github.com/microsoft/windows-rs/blob/945130accc25ac18a47054115e861ca704a37eb5/crates/libs/core/src/imp/factory_cache.rs#L73