### PR TITLE
Fix win7 build

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -252,35 +252,36 @@ fn create_locator() -> windows_core::Result<IWbemLocator> {
     Ok(loc)
 }
 
+#[cfg(target_vendor = "win7")]
 fn create_locator_or_init() -> windows_core::Result<IWbemLocator> {
+    // `CoIncrementMTAUsage` is not available on Windows 7,
+    // so it is the responsibly of the caller to initialize COM and the security layer,
+    // using `CoInitializeEx` and `CoInitializeSecurity`, respectively.
+    create_locator()
+}
+
+#[cfg(not(target_vendor = "win7"))]
+fn create_locator_or_init() -> windows_core::Result<IWbemLocator> {
+    use windows::Win32::Foundation::RPC_E_TOO_LATE;
+    use windows::Win32::System::Com::CoIncrementMTAUsage;
+
     let loc_res = create_locator();
     match loc_res {
         // If COM is not initialized, initialize it and try again.
         // Based on [`load_factory`](https://github.com/microsoft/windows-rs/blob/945130accc25ac18a47054115e861ca704a37eb5/crates/libs/core/src/imp/factory_cache.rs#L73)
         // from the `windows-rs` crate.
         Err(err) if err.code() == CO_E_NOTINITIALIZED => {
-            #[cfg(target_vendor = "win7")]
+            let _ = unsafe { CoIncrementMTAUsage() }?;
+            let sec_result = init_security();
+
+            // If security was initialized already, there's no need to return an error.
+            if let Err(err) = &sec_result
+                && err.code() != RPC_E_TOO_LATE
             {
-                Err(err)
+                sec_result?;
             }
 
-            #[cfg(not(target_vendor = "win7"))]
-            {
-                use windows::Win32::Foundation::RPC_E_TOO_LATE;
-                use windows::Win32::System::Com::CoIncrementMTAUsage;
-
-                let _ = unsafe { CoIncrementMTAUsage() }?;
-                let sec_result = init_security();
-
-                // If security was initialized already, there's no need to return an error.
-                if let Err(err) = &sec_result
-                    && err.code() != RPC_E_TOO_LATE
-                {
-                    sec_result?;
-                }
-
-                create_locator()
-            }
+            create_locator()
         }
         loc_res => loc_res,
     }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -2,13 +2,12 @@ use crate::context::WMIContext;
 use crate::utils::WMIResult;
 use log::debug;
 use std::marker::PhantomData;
-use windows::Win32::Foundation::{CO_E_NOTINITIALIZED, RPC_E_TOO_LATE};
+use windows::Win32::Foundation::CO_E_NOTINITIALIZED;
 use windows::Win32::System::Com::{
-    CLSCTX_INPROC_SERVER, CoCreateInstance, CoIncrementMTAUsage, CoInitializeSecurity,
-    CoSetProxyBlanket, EOAC_NONE, RPC_C_AUTHN_LEVEL, RPC_C_AUTHN_LEVEL_CALL,
-    RPC_C_AUTHN_LEVEL_CONNECT, RPC_C_AUTHN_LEVEL_DEFAULT, RPC_C_AUTHN_LEVEL_NONE,
-    RPC_C_AUTHN_LEVEL_PKT, RPC_C_AUTHN_LEVEL_PKT_INTEGRITY, RPC_C_AUTHN_LEVEL_PKT_PRIVACY,
-    RPC_C_IMP_LEVEL_IMPERSONATE,
+    CLSCTX_INPROC_SERVER, CoCreateInstance, CoSetProxyBlanket, EOAC_NONE, RPC_C_AUTHN_LEVEL,
+    RPC_C_AUTHN_LEVEL_CALL, RPC_C_AUTHN_LEVEL_CONNECT, RPC_C_AUTHN_LEVEL_DEFAULT,
+    RPC_C_AUTHN_LEVEL_NONE, RPC_C_AUTHN_LEVEL_PKT, RPC_C_AUTHN_LEVEL_PKT_INTEGRITY,
+    RPC_C_AUTHN_LEVEL_PKT_PRIVACY, RPC_C_IMP_LEVEL_IMPERSONATE,
 };
 use windows::Win32::System::Rpc::{RPC_C_AUTHN_WINNT, RPC_C_AUTHZ_NONE};
 use windows::Win32::System::Wmi::{
@@ -53,7 +52,9 @@ impl From<AuthLevel> for RPC_C_AUTHN_LEVEL {
     }
 }
 
+#[cfg(not(target_vendor = "win7"))]
 fn init_security() -> windows_core::Result<()> {
+    use windows::Win32::System::Com::CoInitializeSecurity;
     unsafe {
         CoInitializeSecurity(
             None,
@@ -258,17 +259,28 @@ fn create_locator_or_init() -> windows_core::Result<IWbemLocator> {
         // Based on [`load_factory`](https://github.com/microsoft/windows-rs/blob/945130accc25ac18a47054115e861ca704a37eb5/crates/libs/core/src/imp/factory_cache.rs#L73)
         // from the `windows-rs` crate.
         Err(err) if err.code() == CO_E_NOTINITIALIZED => {
-            let _ = unsafe { CoIncrementMTAUsage() }?;
-            let sec_result = init_security();
-
-            // If security was initialized already, there's no need to return an error.
-            if let Err(err) = &sec_result
-                && err.code() != RPC_E_TOO_LATE
+            #[cfg(target_vendor = "win7")]
             {
-                sec_result?;
+                Err(err)
             }
 
-            create_locator()
+            #[cfg(not(target_vendor = "win7"))]
+            {
+                use windows::Win32::Foundation::RPC_E_TOO_LATE;
+                use windows::Win32::System::Com::CoIncrementMTAUsage;
+
+                let _ = unsafe { CoIncrementMTAUsage() }?;
+                let sec_result = init_security();
+
+                // If security was initialized already, there's no need to return an error.
+                if let Err(err) = &sec_result
+                    && err.code() != RPC_E_TOO_LATE
+                {
+                    sec_result?;
+                }
+
+                create_locator()
+            }
         }
         loc_res => loc_res,
     }


### PR DESCRIPTION
`CoIncrementMTAUsage`  is only available since Windows 8. I need to support Windows 7 (using the target `x86_64-win7-windows-msvc`).

This patch moves the call to `CoIncrementMTAUsage`  behind a dynamic load instead of linking against it.